### PR TITLE
Include Digital Credential Issuance in the Spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
     <section id="abstract">
       <p>
         This document specifies an API to enable [=user agents=] to mediate
-        access to, presentation of, and issuance of digital credentials such 
+        presentation and issuance of digital credentials such 
         as a driver's license, government-issued identification card, 
         and/or [=credential type examples|other types of digital credential=]. 
         The API builds on [[[credential-management-1]]] as a means by which to 
@@ -66,7 +66,7 @@
     </h2>
     <p>
       This document defines an API enabling a website to request presentation 
-      or issuance of a [=digital credential=].
+      and issuance of a [=digital credential=].
     </p>
     <p>
       The API design is agnostic to both credential presentation and issuance [=digital
@@ -99,8 +99,7 @@
       </li>
       <li>Enable platform-provided credential selection UX when multiple wallet
       applications have credentials that match a [=digital
-      credential/presentation request=] or [=digital
-      credential/issuance request=].
+      credential/presentation request=].
       </li>
       <li>Enable platform-provided wallet selection UX when multiple wallet
         applications support an [=digital credential/issuance request=].
@@ -183,7 +182,7 @@
       </dt>
       <dd>
         An issuance request is a request to issue a [=digital credential=]
-        composed of an [=digital credential/credential offer=] and a [=digital
+        composed of a [=digital credential/credential offer=] and an [=digital
         credential/exchange protocol=].
       </dd>
       <dt>
@@ -229,7 +228,7 @@
       anything about a given [=request=] unless the [=holder=] explicitly
       consents to use that software.
       </li>
-      <li>Issuance process for establishing a [=digital credential=].
+      <li>Requesting issuance of a [=digital credential=].
       </li>
     </ul>
     <p>

--- a/index.html
+++ b/index.html
@@ -190,17 +190,16 @@
         <dfn data-dfn-for="digital credential">credential offer</dfn>
       </dt>
       <dd>
-        A format that [=issuer=] software or a [=user agent=] uses, via an
-        [=digital credential/exchange protocol=], to offer issuing a [=digital
-        credential=] from an [=issuer=].
+        A data structure that [=issuer=] or [=user agent=] software uses, via an
+        [=digital credential/exchange protocol=], to offer issuance of a [=digital
+        credential=] by an [=issuer=].
       </dd>
       <dt>
-        <dfn data-dfn-for="digital credential" data-local-lt=
-        "issuance response">Issuance response</dfn>
+        <dfn data-dfn-for="digital credential">Issuance response</dfn>
       </dt>
       <dd>
-        A format that a [=holder|holder's=] software, such as a digital wallet,
-        uses, via an [=digital credential/exchange protocol=], to respond to an
+        A format that [=holder=] software, such as a digital wallet,
+        uses, via an [=digital credential/exchange protocol=], to respond to a
         [=digital credential/credential offer=] by an [=issuer=].
       </dd>
       <dt>

--- a/index.html
+++ b/index.html
@@ -376,7 +376,7 @@
       The {{DigitalCredentialRequest}} dictionary represents an [=digital
       credential/issuance request=]. It is used to specify an [=digital
       credential/exchange protocol=] and a [=digital credential/credential offer=],
-      which the user agent MAY forward to a software used by a holder, such as
+      which the user agent MAY forward to [=holder=] software, such as
       a digital wallet.
     </p>
     <pre class="idl">
@@ -463,7 +463,10 @@
     <p>
       When invoked, the <dfn class="export" data-dfn-for=
       "DigitalCredential">[[\Create]](origin, options,
-      sameOriginWithAncestors)</dfn> internal method MUST:
+      sameOriginWithAncestors)</dfn> internal method MUST, if the user agent doesn't 
+      support issuance, call the default implementation of {{Credential}}'s 
+      {{Credential/[[Create]](origin,options, sameOriginWithAncestors)}} 
+      internal method with the same arguments. Otherwise, it MUST:
     </p>
     <ol class="algorithm">
       <li>Let |global| be [=this=]'s [=relevant global object=].

--- a/index.html
+++ b/index.html
@@ -389,7 +389,7 @@
       The <dfn data-dfn-for="DigitalCredentialCreationOptions">data</dfn> member is a
       [=digital credential/credential offer=] that conforms to some standard in the
       [[[#protocol-registry]]], to be handled by [=holder=]
-      software, such as a digital wallet.
+      software, such as a digital wallet, that conforms to some standard in the [[[#protocol-registry]]].
     </p>
     <h3>
       Integration with Credential Management API

--- a/index.html
+++ b/index.html
@@ -49,11 +49,11 @@
     <section id="abstract">
       <p>
         This document specifies an API to enable [=user agents=] to mediate
-        presentation and issuance of digital credentials such 
-        as a driver's license, government-issued identification card, 
-        and/or [=credential type examples|other types of digital credential=]. 
-        The API builds on [[[credential-management-1]]] as a means by which to 
-        request or issue a digital credential from a user agent or underlying platform.
+        presentation and issuance of digital credentials such as a driver's
+        license, government-issued identification card, and/or [=credential
+        type examples|other types of digital credential=]. The API builds on
+        [[[credential-management-1]]] as a means by which to request or issue a
+        digital credential from a user agent or underlying platform.
       </p>
     </section>
     <section id="sotd">
@@ -65,59 +65,59 @@
       Introduction
     </h2>
     <p>
-      This document defines an API enabling a website to request presentation 
+      This document defines an API enabling a website to request presentation
       and issuance of a [=digital credential=].
     </p>
     <p>
-      The API design is agnostic to both credential 
-      [=digital credential/presentation requests|presentation=] [=digital
-      credential/exchange protocols=], credential 
-      [=digital credential/issuance request|issuance=] [=digital
-      credential/issuance protocols|protocols=] and credential formats. However, to
-      promote interoperability this document includes a
-      [[[#protocol-registry]]].
+      The API design is agnostic to both credential [=digital
+      credential/presentation requests|presentation=] [=digital
+      credential/exchange protocols=], credential [=digital credential/issuance
+      request|issuance=] [=digital credential/issuance protocols|protocols=]
+      and credential formats. However, to promote interoperability this
+      document includes a [[[#protocol-registry]]].
     </p>
     <p>
       The API is designed to support the following goals:
     </p>
     <ul>
-      <li>Keep the acts of [=digital credential/presentation requests|requesting=] 
-      and [=digital credential/issuance requests|issuing=] separate from 
-      the specific [=digital credential/exchange protocol=] and 
-      [=digital credential/issuance protocol=] respectively; thereby enabling 
-      the extensibility of such protocols and credential formats.
+      <li>Keep the acts of [=digital credential/presentation
+      requests|requesting=] and [=digital credential/issuance
+      requests|issuing=] separate from the specific [=digital
+      credential/exchange protocol=] and [=digital credential/issuance
+      protocol=] respectively; thereby enabling the extensibility of such
+      protocols and credential formats.
       </li>
-      <li>Require [=digital credential/presentation requests=] and 
-      [=digital credential/issuance requests=] to be unencrypted, enabling
-      user-agent inspection for risk analysis.
+      <li>Require [=digital credential/presentation requests=] and [=digital
+      credential/issuance requests=] to be unencrypted, enabling user-agent
+      inspection for risk analysis.
       </li>
-      <li>Assume opaque (i.e., encrypted) [=digital credential/presentation responses=]
-      and [=digital credential/issuance responses=],
-      enabling issuers, verifiers and holders to control where
-      potentially sensitive personally identifiable information is exposed.
+      <li>Assume opaque (i.e., encrypted) [=digital credential/presentation
+      responses=] and [=digital credential/issuance responses=], enabling
+      issuers, verifiers and holders to control where potentially sensitive
+      personally identifiable information is exposed.
       </li>
       <li>Require [=transient activation=] to perform [=digital
-      credential/presentation requests=] or [=digital
-      credential/issuance requests=], ensuring that sites cannot silently query for
-      nor issue digital credentials, nor communicate with wallet providers, without
-      the user's active participation and confirmation of each action.
+      credential/presentation requests=] or [=digital credential/issuance
+      requests=], ensuring that sites cannot silently query for nor issue
+      digital credentials, nor communicate with wallet providers, without the
+      user's active participation and confirmation of each action.
       </li>
       <li>Enable platform-provided credential selection UX when multiple wallet
       applications have credentials that match a [=digital
       credential/presentation request=].
       </li>
       <li>Enable platform-provided wallet selection UX when multiple wallet
-        applications support an [=digital credential/issuance request=].
-        </li>
+      applications support an [=digital credential/issuance request=].
+      </li>
       <li>Enable platforms to provide secure cross-device [=digital
-      credential/presentation requests=] and [=digital
-      credential/issuance requests=] with proximity checks.
+      credential/presentation requests=] and [=digital credential/issuance
+      requests=] with proximity checks.
       </li>
     </ul>
     <p id="credential-type-examples">
-      [=Digital credentials=] of many types can be presented and issued using this
-      API. <dfn data-lt="credential type examples">Examples of these types</dfn>
-      include:
+      [=Digital credentials=] of many types can be presented and issued using
+      this API. <dfn data-lt="credential type examples">Examples of these
+      types</dfn> include:
     </p>
     <ul>
       <li>a driving license, passport, or other identity card issued by a
@@ -178,32 +178,34 @@
         "presentation response">Presentation response</dfn>
       </dt>
       <dd>
-        A format that a [=holder's=] software, such as a digital wallet,
-        uses, via an [=digital credential/exchange protocol=], to respond to a
+        A format that a [=holder's=] software, such as a digital wallet, uses,
+        via an [=digital credential/exchange protocol=], to respond to a
         [=digital credential/presentation request=] by a [=verifier=].
       </dd>
       <dt>
-        <dfn data-dfn-for="digital credential" data-local-lt="issuance">Issuance request</dfn>
+        <dfn data-dfn-for="digital credential" data-local-lt=
+        "issuance">Issuance request</dfn>
       </dt>
       <dd>
         An issuance request is a request to issue a [=digital credential=]
-        composed of a [=digital credential/issuance request data=] and an [=digital
-        credential/issuance protocol=].
+        composed of a [=digital credential/issuance request data=] and an
+        [=digital credential/issuance protocol=].
       </dd>
       <dt>
         <dfn data-dfn-for="digital credential">issuance request data</dfn>
       </dt>
       <dd>
         A data structure that an [=issuer=] or a [=user agent=], via an
-        [=digital credential/issuance protocol=], to request the issuance of a [=digital
-        credential=] by an [=issuer=].
+        [=digital credential/issuance protocol=], to request the issuance of a
+        [=digital credential=] by an [=issuer=].
       </dd>
       <dt>
         <dfn data-dfn-for="digital credential">Issuance response</dfn>
       </dt>
       <dd>
-        A format that [=holder=] uses, via an [=digital credential/issuance protocol=], to respond to an
-        [=digital credential/issuance request=] by an [=issuer=].
+        A format that [=holder=] uses, via an [=digital credential/issuance
+        protocol=], to respond to an [=digital credential/issuance request=] by
+        an [=issuer=].
       </dd>
       <dt>
         <dfn data-dfn-for="digital credential" data-local-lt=
@@ -218,9 +220,9 @@
         "issuance protocol">Issuance protocol</dfn>
       </dt>
       <dd>
-        A protocol used for communication between an [=issuer=] and a [=holder=] 
-        during the issuance of a [=digital credential=]. 
-        See section [[[#protocol-registry]]].
+        A protocol used for communication between an [=issuer=] and a
+        [=holder=] during the issuance of a [=digital credential=]. See section
+        [[[#protocol-registry]]].
       </dd>
     </dl>
     <h2>
@@ -314,19 +316,19 @@
     <p>
       The <dfn data-dfn-for="DigitalCredentialCreationOptions">requests</dfn>
       specify an [=digital credential/issuance protocol=] and [=digital
-      credential/request data=], which the user agent MAY forward to a [=holder=].
+      credential/request data=], which the user agent MAY forward to a
+      [=holder=].
     </p>
     <h2>
       The `DigitalCredentialRequest` dictionary
     </h2>
     <p>
       The {{DigitalCredentialRequest}} dictionary represents a [=digital
-      credential/presentation request=] or an [=digital credential/issuance request=]. 
-      During presentation, it is used to specify an [=digital
+      credential/presentation request=] or an [=digital credential/issuance
+      request=]. During presentation, it is used to specify an [=digital
       credential/exchange protocol=] and a [=digital credential/request data=],
       which the user agent MAY match against software used by a holder, such as
-      a digital wallet.
-      During issuance, it is used to specify an [=digital
+      a digital wallet. During issuance, it is used to specify an [=digital
       credential/issuance protocol=] and a [=digital credential/request data=],
       to communicate the issuance request between the issuer and the holder.
     </p>
@@ -342,8 +344,8 @@
     <p>
       The <dfn data-dfn-for="DigitalCredentialRequest">protocol</dfn> member
       denotes the [=digital credential/exchange protocol=] when requesting a
-      digital credential, and the [=digital credential/issuance protocol=] 
-      when issuing a digital credential.
+      digital credential, and the [=digital credential/issuance protocol=] when
+      issuing a digital credential.
     </p>
     <p>
       The {{DigitalCredentialRequest/protocol}} member's value is be one of the
@@ -392,7 +394,7 @@
     <p>
       The <dfn data-dfn-for="DigitalCredential">protocol</dfn> member is the
       [=digital credential/exchange protocol=] that was used to request the
-      [=digital credential=], or the [=digital credential/issuance protocol=] 
+      [=digital credential=], or the [=digital credential/issuance protocol=]
       that was used to issue the [=digital credential=].
     </p>
     <h3>
@@ -460,9 +462,9 @@
     <p>
       When invoked, the <dfn class="export" data-dfn-for=
       "DigitalCredential">[[\Create]](origin, options,
-      sameOriginWithAncestors)</dfn> internal method, if the user agent doesn't 
-      support issuance, call the default implementation of {{Credential}}'s 
-      {{Credential/[[Create]](origin,options, sameOriginWithAncestors)}} 
+      sameOriginWithAncestors)</dfn> internal method, if the user agent doesn't
+      support issuance, call the default implementation of {{Credential}}'s
+      {{Credential/[[Create]](origin,options, sameOriginWithAncestors)}}
       internal method with the same arguments. Otherwise:
     </p>
     <ol class="algorithm">
@@ -480,20 +482,22 @@
       <li>[=Consume user activation=] of |window|.
       </li>
       <li>Let |requests| be |options|'s {{CredentialCreationOptions/digital}}'s
-        {{DigitalCredentialCreationOptions/requests}} member.
-        </li>
-        <li>If |requests| is empty, [=exception/throw=] a {{TypeError}}.
-        </li>
-        <li>
-          <aside class="issue">
-            Details of how to actually issue the [=digital credential=] are
-            forthcoming.
-          </aside>
-        </li>
-        <li>Return a newly constructed {{DigitalCredential}} with {{DigitalCredential/protocol}}
-          initialized to the protocol that was used to issue this credential, and 
-          {{DigitalCredential/data}} initialized to an [=digital credential/issuance response=] defined by that [=digital credential/issuance protocol=].
-        </li>
+      {{DigitalCredentialCreationOptions/requests}} member.
+      </li>
+      <li>If |requests| is empty, [=exception/throw=] a {{TypeError}}.
+      </li>
+      <li>
+        <aside class="issue">
+          Details of how to actually issue the [=digital credential=] are
+          forthcoming.
+        </aside>
+      </li>
+      <li>Return a newly constructed {{DigitalCredential}} with
+      {{DigitalCredential/protocol}} initialized to the protocol that was used
+      to issue this credential, and {{DigitalCredential/data}} initialized to
+      an [=digital credential/issuance response=] defined by that [=digital
+      credential/issuance protocol=].
+      </li>
     </ol>
     <h3>
       [[\type]] internal slot
@@ -538,8 +542,8 @@
     </h2>
     <p>
       The following is the registry of [=digital credential/exchange
-      protocols=] and [=digital credential/issuance protocols=] 
-      that are supported by this specification.
+      protocols=] and [=digital credential/issuance protocols=] that are
+      supported by this specification.
     </p>
     <p class="note" title="Official Registry" data-cite="w3c-process">
       It is expected that this registry will be become a [=W3C registry=] in

--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
       </dt>
       <dd>
         An issuance request is a request to issue a [=digital credential=]
-        composed of a [=digital credential/issuance request data=] and an
+        composed of some [=digital credential/issuance request data=] and an
         [=digital credential/issuance protocol=].
       </dd>
       <dt>
@@ -293,7 +293,7 @@
     <p>
       The {{DigitalCredentialGetRequest}} dictionary represents a [=digital
       credential/presentation request=]. It is used to specify an [=digital
-      credential/exchange protocol=] and a [=digital credential/request data=],
+      credential/exchange protocol=] and some [=digital credential/request data=],
       which the user agent MAY match against software used by a holder, such as
       a digital wallet.
     </p>
@@ -361,7 +361,7 @@
     <p>
       The {{DigitalCredentialCreateRequest}} dictionary represents an [=digital
       credential/issuance request=]. It is used to specify an [=digital
-      credential/issuance protocol=] and a [=digital credential/request data=],
+      credential/issuance protocol=] and some [=digital credential/request data=],
       to communicate the issuance request between the issuer and the holder.
     </p>
     <pre class="idl">

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
       <li>Require [=transient activation=] to perform [=digital
       credential/presentation requests=] or [=digital
       credential/issuance requests=], ensuring that sites cannot silently query for
-      nor offer digital credentials, nor communicate with wallet providers, without
+      nor issue digital credentials, nor communicate with wallet providers, without
       the user's active participation and confirmation of each action.
       </li>
       <li>Enable platform-provided credential selection UX when multiple wallet
@@ -187,11 +187,11 @@
       </dt>
       <dd>
         An issuance request is a request to issue a [=digital credential=]
-        composed of a [=digital credential/credential offer=] and an [=digital
-        credential/exchange protocol=].
+        composed of a [=digital credential/issuance request data=] and an [=digital
+        credential/issuance protocol=].
       </dd>
       <dt>
-        <dfn data-dfn-for="digital credential">credential offer</dfn>
+        <dfn data-dfn-for="digital credential">issuance request data</dfn>
       </dt>
       <dd>
         A data structure that an [=issuer=] or a [=user agent=], via an
@@ -202,9 +202,8 @@
         <dfn data-dfn-for="digital credential">Issuance response</dfn>
       </dt>
       <dd>
-        A format that [=holder=] software, such as a digital wallet,
-        uses, via an [=digital credential/issuance protocol=], to respond to a
-        [=digital credential/credential offer=] by an [=issuer=].
+        A format that [=holder=] uses, via an [=digital credential/issuance protocol=], to respond to an
+        [=digital credential/issuance request=] by an [=issuer=].
       </dd>
       <dt>
         <dfn data-dfn-for="digital credential" data-local-lt=

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
       <li>Keep the acts of [=digital credential/presentation requests|requesting=] 
       and [=digital credential/issuance requests|issuing=] separate from 
       the specific [=digital credential/exchange protocol=] and 
-      [=digital credential/issuance protocol=] respectively. thereby enabling 
+      [=digital credential/issuance protocol=] respectively; thereby enabling 
       the extensibility of such protocols and credential formats.
       </li>
       <li>Require [=digital credential/presentation requests=] and 
@@ -194,8 +194,8 @@
         <dfn data-dfn-for="digital credential">credential offer</dfn>
       </dt>
       <dd>
-        A data structure that an [=issuer=] or a [=user agent=] software uses, via an
-        [=digital credential/issuance protocol=], to offer the issuance of a [=digital
+        A data structure that an [=issuer=] or a [=user agent=], via an
+        [=digital credential/issuance protocol=], to request the issuance of a [=digital
         credential=] by an [=issuer=].
       </dd>
       <dt>
@@ -315,8 +315,7 @@
     <p>
       The <dfn data-dfn-for="DigitalCredentialCreationOptions">requests</dfn>
       specify an [=digital credential/issuance protocol=] and [=digital
-      credential/request data=], which the user agent MAY forward to a [=holder=] 
-      software, such as a digital wallet.
+      credential/request data=], which the user agent MAY forward to a [=holder=].
     </p>
     <h2>
       The `DigitalCredentialRequest` dictionary
@@ -462,10 +461,10 @@
     <p>
       When invoked, the <dfn class="export" data-dfn-for=
       "DigitalCredential">[[\Create]](origin, options,
-      sameOriginWithAncestors)</dfn> internal method MUST, if the user agent doesn't 
+      sameOriginWithAncestors)</dfn> internal method, if the user agent doesn't 
       support issuance, call the default implementation of {{Credential}}'s 
       {{Credential/[[Create]](origin,options, sameOriginWithAncestors)}} 
-      internal method with the same arguments. Otherwise, it MUST:
+      internal method with the same arguments. Otherwise:
     </p>
     <ol class="algorithm">
       <li>Let |global| be [=this=]'s [=relevant global object=].
@@ -494,7 +493,7 @@
         </li>
         <li>Return a newly constructed {{DigitalCredential}} with {{DigitalCredential/protocol}}
           initialized to the protocol that was used to issue this credential, and 
-          {{DigitalCredential/data}} initialized to a response defined by that protocol.
+          {{DigitalCredential/data}} initialized to an [=digital credential/issuance response=] defined by that [=digital credential/issuance protocol=].
         </li>
     </ol>
     <h3>

--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@
         "presentation response">Presentation response</dfn>
       </dt>
       <dd>
-        A format that a [=holder|holder's=] software, such as a digital wallet,
+        A format that a [=holder's=] software, such as a digital wallet,
         uses, via an [=digital credential/exchange protocol=], to respond to a
         [=digital credential/presentation request=] by a [=verifier=].
       </dd>
@@ -182,7 +182,7 @@
         <dfn data-dfn-for="digital credential" data-local-lt="issuance">Issuance request</dfn>
       </dt>
       <dd>
-        An issuance request is an offer to issue a [=digital credential=]
+        An issuance request is a request to issue a [=digital credential=]
         composed of an [=digital credential/credential offer=] and a [=digital
         credential/exchange protocol=].
       </dd>
@@ -338,6 +338,22 @@
     <p>
       {{DigitalCredential}} instances are [=Credential/origin bound=].
     </p>
+    <h3>
+      The `protocol` member
+    </h3>
+    <p>
+      The <dfn data-dfn-for="DigitalCredential">protocol</dfn> member is the
+      [=digital credential/exchange protocol=] that was used to request the
+      [=digital credential=].
+    </p>
+    <h3>
+      The `data` member
+    </h3>
+    <p>
+      The <dfn data-dfn-for="DigitalCredential">data</dfn> member is the
+      credential's response data. It contains the subset of JSON-parseable
+      object types.
+    </p>
     <h2>
       Extensions to `CredentialCreationOptions` dictionary
     </h2>
@@ -357,7 +373,7 @@
       The `DigitalCredentialCreationOptions` dictionary
     </h2>
     <p>
-      The {{DigitalCredentialRequest}} dictionary represents a [=digital
+      The {{DigitalCredentialRequest}} dictionary represents an [=digital
       credential/issuance request=]. It is used to specify an [=digital
       credential/exchange protocol=] and a [=digital credential/credential offer=],
       which the user agent MAY forward to a software used by a holder, such as
@@ -387,30 +403,13 @@
     </h3>
     <p>
       The <dfn data-dfn-for="DigitalCredentialCreationOptions">data</dfn> member is a
-      [=digital credential/credential offer=] that conforms to some standard in the
-      [[[#protocol-registry]]], to be handled by [=holder=]
+      [=digital credential/credential offer=] to be handled by [=holder=]
       software, such as a digital wallet, that conforms to some standard in the [[[#protocol-registry]]].
     </p>
-    <h3>
+    <h2>
       Integration with Credential Management API
-    </h3>
+    </h2>
     <aside class="issue" data-number="65"></aside>
-    <h3>
-      The `protocol` member
-    </h3>
-    <p>
-      The <dfn data-dfn-for="DigitalCredential">protocol</dfn> member is the
-      [=digital credential/exchange protocol=] that was used to request the
-      [=digital credential=].
-    </p>
-    <h3>
-      The `data` member
-    </h3>
-    <p>
-      The <dfn data-dfn-for="DigitalCredential">data</dfn> member is the
-      credential's response data. It contains the subset of JSON-parseable
-      object types.
-    </p>
     <h3>
       [[\DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)
       internal method

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
       or issuance of a [=digital credential=].
     </p>
     <p>
-      The API design is agnostic to both credential presentation/issuance [=digital
+      The API design is agnostic to both credential presentation and issuance [=digital
       credential/exchange protocols=] and credential formats. However, to
       promote interoperability this document includes a
       [[[#protocol-registry]]].

--- a/index.html
+++ b/index.html
@@ -69,9 +69,11 @@
       and issuance of a [=digital credential=].
     </p>
     <p>
-      The API design is agnostic to both credential presentation [=digital
-      credential/exchange protocols=], credential [=digital
-      credential/issuance protocols=] and credential formats. However, to
+      The API design is agnostic to both credential 
+      [=digital credential/presentation requests|presentation=] [=digital
+      credential/exchange protocols=], credential 
+      [=digital credential/issuance request|issuance=] [=digital
+      credential/issuance protocols|protocols=] and credential formats. However, to
       promote interoperability this document includes a
       [[[#protocol-registry]]].
     </p>
@@ -79,10 +81,11 @@
       The API is designed to support the following goals:
     </p>
     <ul>
-      <li>Keep the acts of requesting and issuance separate from the specific [=digital
-      credential/exchange protocol=] and [=digital credential/issuance protocol=] 
-      respectively. thereby enabling the extensibility of such protocols and 
-      credential formats.
+      <li>Keep the acts of [=digital credential/presentation requests|requesting=] 
+      and [=digital credential/issuance requests|issuing=] separate from 
+      the specific [=digital credential/exchange protocol=] and 
+      [=digital credential/issuance protocol=] respectively. thereby enabling 
+      the extensibility of such protocols and credential formats.
       </li>
       <li>Require [=digital credential/presentation requests=] and 
       [=digital credential/issuance requests=] to be unencrypted, enabling
@@ -155,7 +158,7 @@
       </dd>
       <dt>
         <dfn data-dfn-for="digital credential" data-local-lt=
-        "presentation requests">Presentation request</dfn>
+        "presentation">Presentation request</dfn>
       </dt>
       <dd>
         A presentation request is a request for a [=digital credential=]

--- a/index.html
+++ b/index.html
@@ -82,36 +82,37 @@
       credential/protocol=], thereby enabling the extensibility of the
       [=digital credential/protocol=] and credential formats.
       </li>
-      <li>Require [=digital credential/presentation requests=] and [=digital credential/issuance request=] to be unencrypted, enabling
+      <li>Require [=digital credential/presentation requests=] and 
+      [=digital credential/issuance requests=] to be unencrypted, enabling
       user-agent inspection for risk analysis.
       </li>
-      <li>Assume [=digital credential/presentation response=] and 
-      [=digital credential/issuance response=] opacity (encrypted responses), 
-      enabling issuers,  verifiers and holders to control where
+      <li>Assume opaque (i.e., encrypted) [=digital credential/presentation responses=]
+      and [=digital credential/issuance responses=],
+      enabling issuers, verifiers and holders to control where
       potentially sensitive personally identifiable information is exposed.
       </li>
       <li>Require [=transient activation=] to perform [=digital
       credential/presentation requests=] or [=digital
-      credential/issuance request=], ensuring that sites cannot silently query for/offer
-      digital credentials nor communicate with wallet providers without the
-      user's active participation and confirmation of each action.
+      credential/issuance requests=], ensuring that sites cannot silently query for
+      nor offer digital credentials, nor communicate with wallet providers, without
+      the user's active participation and confirmation of each action.
       </li>
       <li>Enable platform-provided credential selection UX when multiple wallet
-      applications have credentials that match [=digital
-      credential/presentation requests=] or an [=digital
+      applications have credentials that match a [=digital
+      credential/presentation request=] or [=digital
       credential/issuance request=].
       </li>
       <li>Enable platform-provided wallet selection UX when multiple wallet
-        applications support the issuance request.
+        applications support an [=digital credential/issuance request=].
         </li>
-      <li>Enable platforms to potentially provide secure cross-device [=digital
-      credential/presentation requests=] and  [=digital
-      credential/issuance request=] with proximity checks.
+      <li>Enable platforms to provide secure cross-device [=digital
+      credential/presentation requests=] and [=digital
+      credential/issuance requests=] with proximity checks.
       </li>
     </ul>
     <p id="credential-type-examples">
-      [=Digital credentials=] of many types can be presented/issued using this API.
-      <dfn data-lt="credential type examples">Examples of these types</dfn>
+      [=Digital credentials=] of many types can be presented and issued using this
+      API. <dfn data-lt="credential type examples">Examples of these types</dfn>
       include:
     </p>
     <ul>
@@ -175,11 +176,10 @@
       <dd>
         A format that a [=holder|holder's=] software, such as a digital wallet,
         uses, via an [=digital credential/exchange protocol=], to respond to a
-        [=digital credential/request data=] by a [=verifier=].
+        [=digital credential/presentation request=] by a [=verifier=].
       </dd>
       <dt>
-        <dfn data-dfn-for="digital credential" data-local-lt=
-        "issuance request">Issuance request</dfn>
+        <dfn data-dfn-for="digital credential" data-local-lt="issuance">Issuance request</dfn>
       </dt>
       <dd>
         An issuance request is an offer to issue a [=digital credential=]
@@ -378,16 +378,17 @@
       digital credential.
     </p>
     <p>
-      The {{DigitalCredentialCreationOptions/protocol}} member's value is be one of the
-      well-defined keys defined in [[[#protocol-registry]]] or any other custom
-      one.
+      The {{DigitalCredentialCreationOptions/protocol}} member's value is a
+      well-defined key as defined in [[[#protocol-registry]]] or a custom
+      key as defined by an implementation or deployment.
     </p>
     <h3>
       The `data` member
     </h3>
     <p>
-      The <dfn data-dfn-for="DigitalCredentialCreationOptions">data</dfn> member is the
-      [=digital credential/credential offer=] to be handled by the holder's
+      The <dfn data-dfn-for="DigitalCredentialCreationOptions">data</dfn> member is a
+      [=digital credential/credential offer=] that conforms to some standard in the
+      [[[#protocol-registry]]], to be handled by [=holder=]
       software, such as a digital wallet.
     </p>
     <h3>

--- a/index.html
+++ b/index.html
@@ -275,7 +275,7 @@
     </h2>
     <pre class="idl">
     dictionary DigitalCredentialRequestOptions {
-      sequence&lt;DigitalCredentialRequest&gt; requests;
+      sequence&lt;DigitalCredentialGetRequest&gt; requests;
     };
     </pre>
     <h3>
@@ -286,6 +286,42 @@
       specify an [=digital credential/exchange protocol=] and [=digital
       credential/request data=], which the user agent MAY match against a
       holder's software, such as a digital wallet.
+    </p>
+    <h2>
+      The `DigitalCredentialGetRequest` dictionary
+    </h2>
+    <p>
+      The {{DigitalCredentialGetRequest}} dictionary represents a [=digital
+      credential/presentation request=]. It is used to specify an [=digital
+      credential/exchange protocol=] and a [=digital credential/request data=],
+      which the user agent MAY match against software used by a holder, such as
+      a digital wallet.
+    </p>
+    <pre class="idl">
+      dictionary DigitalCredentialGetRequest {
+        required DOMString protocol;
+        required object data;
+      };
+      </pre>
+    <h3>
+      The `protocol` member
+    </h3>
+    <p>
+      The <dfn data-dfn-for="DigitalCredentialGetRequest">protocol</dfn> member
+      denotes the [=digital credential/exchange protocol=].
+    </p>
+    <p>
+      The {{DigitalCredentialCreateRequest/protocol}} member's value is be one
+      of the well-defined keys defined in [[[#protocol-registry]]] or any other
+      custom one.
+    </p>
+    <h3>
+      The `data` member
+    </h3>
+    <p>
+      The <dfn data-dfn-for="DigitalCredentialGetRequest">data</dfn> member is
+      the [=digital credential/request data=] to be handled by the holder's
+      software, such as a digital wallet.
     </p>
     <h2>
       Extensions to `CredentialCreationOptions` dictionary
@@ -307,7 +343,7 @@
     </h2>
     <pre class="idl">
     dictionary DigitalCredentialCreationOptions {
-      sequence&lt;DigitalCredentialRequest&gt; requests;
+      sequence&lt;DigitalCredentialCreateRequest&gt; requests;
     };
     </pre>
     <h3>
@@ -320,20 +356,16 @@
       [=holder=].
     </p>
     <h2>
-      The `DigitalCredentialRequest` dictionary
+      The `DigitalCredentialCreateRequest` dictionary
     </h2>
     <p>
-      The {{DigitalCredentialRequest}} dictionary represents a [=digital
-      credential/presentation request=] or an [=digital credential/issuance
-      request=]. During presentation, it is used to specify an [=digital
-      credential/exchange protocol=] and a [=digital credential/request data=],
-      which the user agent MAY match against software used by a holder, such as
-      a digital wallet. During issuance, it is used to specify an [=digital
+      The {{DigitalCredentialCreateRequest}} dictionary represents an [=digital
+      credential/issuance request=]. It is used to specify an [=digital
       credential/issuance protocol=] and a [=digital credential/request data=],
       to communicate the issuance request between the issuer and the holder.
     </p>
     <pre class="idl">
-    dictionary DigitalCredentialRequest {
+    dictionary DigitalCredentialCreateRequest {
       required DOMString protocol;
       required object data;
     };
@@ -342,22 +374,20 @@
       The `protocol` member
     </h3>
     <p>
-      The <dfn data-dfn-for="DigitalCredentialRequest">protocol</dfn> member
-      denotes the [=digital credential/exchange protocol=] when requesting a
-      digital credential, and the [=digital credential/issuance protocol=] when
-      issuing a digital credential.
+      The <dfn data-dfn-for="DigitalCredentialCreateRequest">protocol</dfn>
+      member denotes the [=digital credential/issuance protocol=].
     </p>
     <p>
-      The {{DigitalCredentialRequest/protocol}} member's value is be one of the
-      well-defined keys defined in [[[#protocol-registry]]] or any other custom
-      one.
+      The {{DigitalCredentialCreateRequest/protocol}} member's value is be one
+      of the well-defined keys defined in [[[#protocol-registry]]] or any other
+      custom one.
     </p>
     <h3>
       The `data` member
     </h3>
     <p>
-      The <dfn data-dfn-for="DigitalCredentialRequest">data</dfn> member is the
-      [=digital credential/request data=] to be handled by the holder's
+      The <dfn data-dfn-for="DigitalCredentialCreateRequest">data</dfn> member
+      is the [=digital credential/request data=] to be handled by the holder's
       software, such as a digital wallet.
     </p>
     <h2>

--- a/index.html
+++ b/index.html
@@ -49,11 +49,11 @@
     <section id="abstract">
       <p>
         This document specifies an API to enable [=user agents=] to mediate
-        access to, and presentation of, digital credentials such as a driver's
-        license, government-issued identification card, and/or [=credential
-        type examples|other types of digital credential=]. The API builds on
-        [[[credential-management-1]]] as a means by which to request a digital
-        credential from a user agent or underlying platform.
+        access to, presentation of, and issuance of digital credentials such 
+        as a driver's license, government-issued identification card, 
+        and/or [=credential type examples|other types of digital credential=]. 
+        The API builds on [[[credential-management-1]]] as a means by which to 
+        request or issue a digital credential from a user agent or underlying platform.
       </p>
     </section>
     <section id="sotd">
@@ -65,11 +65,11 @@
       Introduction
     </h2>
     <p>
-      This document defines an API enabling a website to request presentation
-      of a [=digital credential=].
+      This document defines an API enabling a website to request presentation 
+      or issuance of a [=digital credential=].
     </p>
     <p>
-      The API design is agnostic to both credential presentation [=digital
+      The API design is agnostic to both credential presentation/issuance [=digital
       credential/exchange protocols=] and credential formats. However, to
       promote interoperability this document includes a
       [[[#protocol-registry]]].
@@ -78,7 +78,7 @@
       The API is designed to support the following goals:
     </p>
     <ul>
-      <li>Keep the act of requesting separate from the specific [=digital
+      <li>Keep the act of requesting/issuance separate from the specific [=digital
       credential/protocol=], thereby enabling the extensibility of the
       [=digital credential/protocol=] and credential formats.
       </li>
@@ -98,12 +98,15 @@
       applications have credentials that match a [=digital
       credential/requests=].
       </li>
+      <li>Enable platform-provided wallet selection UX when multiple wallet
+        applications support the issuance request.
+        </li>
       <li>Enable platforms to potentially provide secure cross-device [=digital
       credential/requests=] with proximity checks.
       </li>
     </ul>
     <p id="credential-type-examples">
-      [=Digital credentials=] of many types can be presented using this API.
+      [=Digital credentials=] of many types can be presented/issued using this API.
       <dfn data-lt="credential type examples">Examples of these types</dfn>
       include:
     </p>
@@ -197,13 +200,13 @@
       anything about a given [=request=] unless the [=holder=] explicitly
       consents to use that software.
       </li>
+      <li>Issuance process for establishing a [=digital credential=].
+      </li>
     </ul>
     <p>
       The following items are out of scope:
     </p>
     <ul>
-      <li>Issuance process for establishing a [=digital credential=].
-      </li>
       <li>UI/UX considerations, with the exception of privacy considerations,
       which are addressed to ensure the protection of user data during the
       request process.
@@ -306,6 +309,52 @@
     <p>
       {{DigitalCredential}} instances are [=Credential/origin bound=].
     </p>
+    <h2>
+      Extensions to `CredentialCreationOptions` dictionary
+    </h2>
+    <pre class="idl">
+    partial dictionary CredentialCreationOptions {
+      DigitalCredentialCreationOptions digital;
+    };
+    </pre>
+    <h3>
+      The `digital` member
+    </h3>
+    <p>
+      The <dfn data-dfn-for="CredentialCreationOptions">digital</dfn> member
+      allows for options to configure the issuance of a [=digital credential=].
+    </p>
+    <h2>
+      The `DigitalCredentialCreationOptions` dictionary
+    </h2>
+    <pre class="idl">
+    dictionary DigitalCredentialCreationOptions {
+      required DOMString protocol;
+      required object data;
+    };
+    </pre>
+    <h3>
+      The `protocol` member
+    </h3>
+    <p>
+      The <dfn data-dfn-for="DigitalCredentialCreationOptions">protocol</dfn> member
+      denotes the [=digital credential/exchange protocol=] when issuing a
+      digital credential.
+    </p>
+    <p>
+      The {{DigitalCredentialCreationOptions/protocol}} member's value is be one of the
+      well-defined keys defined in [[[#protocol-registry]]] or any other custom
+      one.
+    </p>
+    <h3>
+      The `data` member
+    </h3>
+    <p>
+      <!-- TODO this isn't accurate, figure out how to phrase this -->
+      The <dfn data-dfn-for="DigitalCredentialCreationOptions">data</dfn> member is the
+      [=digital credential/request data=] to be handled by the holder's
+      software, such as a digital wallet.
+    </p>
     <h3>
       Integration with Credential Management API
     </h3>
@@ -379,11 +428,37 @@
     <p>
       When invoked, the <dfn class="export" data-dfn-for=
       "DigitalCredential">[[\Create]](origin, options,
-      sameOriginWithAncestors)</dfn> internal method MUST call the default
-      implementation of {{Credential}}'s {{Credential/[[Create]](origin,
-      options, sameOriginWithAncestors)}} internal method with the same
-      arguments.
+      sameOriginWithAncestors)</dfn> internal method MUST:
     </p>
+    <ol class="algorithm">
+      <li>Let |global| be [=this=]'s [=relevant global object=].
+      </li>
+      <li>Let |document| be |global|'s [=associated `Document`=].
+      </li>
+      <li>If |document| is not a [=Document/fully active descendant of a
+      top-level traversable with user attention=], [=exception/throw=]
+      {{"NotAllowedError"}} {{DOMException}}.
+      </li>
+      <li>If |window| does not have [=transient activation=],
+      [=exception/throw=] {{"NotAllowedError"}} {{DOMException}}.
+      </li>
+      <li>[=Consume user activation=] of |window|.
+      </li>
+      <li>Let |data| be |options|'s {{CredentialCreationOptions/digital}}'s
+      {{DigitalCredentialCreationOptions/data}} member.
+      </li>
+      <li>If |requests| is empty, [=exception/throw=] a {{TypeError}}.
+      </li>
+      <li>
+        <aside class="issue">
+          Details of how to actually issue the [=digital credential=] are
+          forthcoming.
+        </aside>
+      </li>
+      <!-- Figure out what should be returned here -->
+      <li>Return a {{DigitalCredential}}.
+      </li>
+    </ol>
     <h3>
       [[\type]] internal slot
     </h3>

--- a/index.html
+++ b/index.html
@@ -69,8 +69,9 @@
       and issuance of a [=digital credential=].
     </p>
     <p>
-      The API design is agnostic to both credential presentation and issuance [=digital
-      credential/exchange protocols=] and credential formats. However, to
+      The API design is agnostic to both credential presentation [=digital
+      credential/exchange protocols=], credential [=digital
+      credential/issuance protocols=] and credential formats. However, to
       promote interoperability this document includes a
       [[[#protocol-registry]]].
     </p>
@@ -79,8 +80,9 @@
     </p>
     <ul>
       <li>Keep the acts of requesting and issuance separate from the specific [=digital
-      credential/protocol=], thereby enabling the extensibility of the
-      [=digital credential/protocol=] and credential formats.
+      credential/exchange protocol=] and [=digital credential/issuance protocol=] 
+      respectively. thereby enabling the extensibility of such protocols and 
+      credential formats.
       </li>
       <li>Require [=digital credential/presentation requests=] and 
       [=digital credential/issuance requests=] to be unencrypted, enabling
@@ -189,8 +191,8 @@
         <dfn data-dfn-for="digital credential">credential offer</dfn>
       </dt>
       <dd>
-        A data structure that [=issuer=] or [=user agent=] software uses, via an
-        [=digital credential/exchange protocol=], to offer issuance of a [=digital
+        A data structure that an [=issuer=] or a [=user agent=] software uses, via an
+        [=digital credential/issuance protocol=], to offer the issuance of a [=digital
         credential=] by an [=issuer=].
       </dd>
       <dt>
@@ -198,16 +200,25 @@
       </dt>
       <dd>
         A format that [=holder=] software, such as a digital wallet,
-        uses, via an [=digital credential/exchange protocol=], to respond to a
+        uses, via an [=digital credential/issuance protocol=], to respond to a
         [=digital credential/credential offer=] by an [=issuer=].
       </dd>
       <dt>
         <dfn data-dfn-for="digital credential" data-local-lt=
-        "protocol">Exchange protocol</dfn>
+        "exchange protocol">Exchange protocol</dfn>
       </dt>
       <dd>
         A protocol used for exchanging a [=digital credential=] between a
         [=holder=] and a [=verifier=]. See section [[[#protocol-registry]]].
+      </dd>
+      <dt>
+        <dfn data-dfn-for="digital credential" data-local-lt=
+        "issuance protocol">Issuance protocol</dfn>
+      </dt>
+      <dd>
+        A protocol used for communication between an [=issuer=] and a [=holder=] 
+        during the issuance of a [=digital credential=]. 
+        See section [[[#protocol-registry]]].
       </dd>
     </dl>
     <h2>
@@ -220,6 +231,8 @@
       <li>Requesting a [=digital credential=], including mechanisms for secure
       presentation.
       </li>
+      <li>Requesting issuance of a [=digital credential=].
+      </li>
       <li>Ensuring that when an API call is made, the website does not learn
       anything about the a holder's [=digital credentials=] or their software
       unless the [=user agent=] has previously received user consent.
@@ -227,8 +240,6 @@
       <li>Ensuring that any installed application software will not learn
       anything about a given [=request=] unless the [=holder=] explicitly
       consents to use that software.
-      </li>
-      <li>Requesting issuance of a [=digital credential=].
       </li>
     </ul>
     <p>
@@ -273,14 +284,50 @@
       holder's software, such as a digital wallet.
     </p>
     <h2>
+      Extensions to `CredentialCreationOptions` dictionary
+    </h2>
+    <pre class="idl">
+    partial dictionary CredentialCreationOptions {
+      DigitalCredentialCreationOptions digital;
+    };
+    </pre>
+    <h3>
+      The `digital` member
+    </h3>
+    <p>
+      The <dfn data-dfn-for="CredentialCreationOptions">digital</dfn> member
+      allows for options to configure the issuance of a [=digital credential=].
+    </p>
+    <h2>
+      The `DigitalCredentialCreationOptions` dictionary
+    </h2>
+    <pre class="idl">
+    dictionary DigitalCredentialCreationOptions {
+      sequence&lt;DigitalCredentialRequest&gt; requests;
+    };
+    </pre>
+    <h3>
+      The `requests` member
+    </h3>
+    <p>
+      The <dfn data-dfn-for="DigitalCredentialCreationOptions">requests</dfn>
+      specify an [=digital credential/issuance protocol=] and [=digital
+      credential/request data=], which the user agent MAY forward to a [=holder=] 
+      software, such as a digital wallet.
+    </p>
+    <h2>
       The `DigitalCredentialRequest` dictionary
     </h2>
     <p>
       The {{DigitalCredentialRequest}} dictionary represents a [=digital
-      credential/presentation request=]. It is used to specify an [=digital
+      credential/presentation request=] or an [=digital credential/issuance request=]. 
+      During presentation, it is used to specify an [=digital
       credential/exchange protocol=] and a [=digital credential/request data=],
       which the user agent MAY match against software used by a holder, such as
       a digital wallet.
+      During issuance, it is used to specify an [=digital
+      credential/issuance protocol=] and a [=digital credential/request data=],
+      to communicate the issuance request between the issuer and the holder.
     </p>
     <pre class="idl">
     dictionary DigitalCredentialRequest {
@@ -293,8 +340,9 @@
     </h3>
     <p>
       The <dfn data-dfn-for="DigitalCredentialRequest">protocol</dfn> member
-      denotes the [=digital credential/exchange protocol=] when requesting an
-      identify credential.
+      denotes the [=digital credential/exchange protocol=] when requesting a
+      digital credential, and the [=digital credential/issuance protocol=] 
+      when issuing a digital credential.
     </p>
     <p>
       The {{DigitalCredentialRequest/protocol}} member's value is be one of the
@@ -343,7 +391,8 @@
     <p>
       The <dfn data-dfn-for="DigitalCredential">protocol</dfn> member is the
       [=digital credential/exchange protocol=] that was used to request the
-      [=digital credential=].
+      [=digital credential=], or the [=digital credential/issuance protocol=] 
+      that was used to issue the [=digital credential=].
     </p>
     <h3>
       The `data` member
@@ -352,58 +401,6 @@
       The <dfn data-dfn-for="DigitalCredential">data</dfn> member is the
       credential's response data. It contains the subset of JSON-parseable
       object types.
-    </p>
-    <h2>
-      Extensions to `CredentialCreationOptions` dictionary
-    </h2>
-    <pre class="idl">
-    partial dictionary CredentialCreationOptions {
-      DigitalCredentialCreationOptions digital;
-    };
-    </pre>
-    <h3>
-      The `digital` member
-    </h3>
-    <p>
-      The <dfn data-dfn-for="CredentialCreationOptions">digital</dfn> member
-      allows for options to configure the issuance of a [=digital credential=].
-    </p>
-    <h2>
-      The `DigitalCredentialCreationOptions` dictionary
-    </h2>
-    <p>
-      The {{DigitalCredentialRequest}} dictionary represents an [=digital
-      credential/issuance request=]. It is used to specify an [=digital
-      credential/exchange protocol=] and a [=digital credential/credential offer=],
-      which the user agent MAY forward to [=holder=] software, such as
-      a digital wallet.
-    </p>
-    <pre class="idl">
-    dictionary DigitalCredentialCreationOptions {
-      required DOMString protocol;
-      required object data;
-    };
-    </pre>
-    <h3>
-      The `protocol` member
-    </h3>
-    <p>
-      The <dfn data-dfn-for="DigitalCredentialCreationOptions">protocol</dfn> member
-      denotes the [=digital credential/exchange protocol=] when issuing a
-      digital credential.
-    </p>
-    <p>
-      The {{DigitalCredentialCreationOptions/protocol}} member's value is a
-      well-defined key as defined in [[[#protocol-registry]]] or a custom
-      key as defined by an implementation or deployment.
-    </p>
-    <h3>
-      The `data` member
-    </h3>
-    <p>
-      The <dfn data-dfn-for="DigitalCredentialCreationOptions">data</dfn> member is a
-      [=digital credential/credential offer=] to be handled by [=holder=]
-      software, such as a digital wallet, that conforms to some standard in the [[[#protocol-registry]]].
     </p>
     <h2>
       Integration with Credential Management API
@@ -481,19 +478,21 @@
       </li>
       <li>[=Consume user activation=] of |window|.
       </li>
-      <li>Let |data| be |options|'s {{CredentialCreationOptions/digital}}'s
-      {{DigitalCredentialCreationOptions/data}} member.
-      </li>
-      <li>If |requests| is empty, [=exception/throw=] a {{TypeError}}.
-      </li>
-      <li>
-        <aside class="issue">
-          Details of how to actually issue the [=digital credential=] are
-          forthcoming.
-        </aside>
-      </li>
-      <li>Return a {{DigitalCredential}}. {{DigitalCredential/protocol}} is the protocol that was used to issue this credential. {{DigitalCredential/data}} is a response defined by the protocol.
-      </li>
+      <li>Let |requests| be |options|'s {{CredentialCreationOptions/digital}}'s
+        {{DigitalCredentialCreationOptions/requests}} member.
+        </li>
+        <li>If |requests| is empty, [=exception/throw=] a {{TypeError}}.
+        </li>
+        <li>
+          <aside class="issue">
+            Details of how to actually issue the [=digital credential=] are
+            forthcoming.
+          </aside>
+        </li>
+        <li>Return a {{DigitalCredential}}. {{DigitalCredential/protocol}} is the 
+          protocol that was used to issue this credential. {{DigitalCredential/data}} is 
+          a response defined by the protocol.
+        </li>
     </ol>
     <h3>
       [[\type]] internal slot
@@ -538,7 +537,8 @@
     </h2>
     <p>
       The following is the registry of [=digital credential/exchange
-      protocols=] that are supported by this specification.
+      protocols=] and [=digital credential/issuance protocols=] 
+      that are supported by this specification.
     </p>
     <p class="note" title="Official Registry" data-cite="w3c-process">
       It is expected that this registry will be become a [=W3C registry=] in

--- a/index.html
+++ b/index.html
@@ -489,9 +489,9 @@
             forthcoming.
           </aside>
         </li>
-        <li>Return a {{DigitalCredential}}. {{DigitalCredential/protocol}} is the 
-          protocol that was used to issue this credential. {{DigitalCredential/data}} is 
-          a response defined by the protocol.
+        <li>Return a newly constructed {{DigitalCredential}} with {{DigitalCredential/protocol}}
+          initialized to the protocol that was used to issue this credential, and 
+          {{DigitalCredential/data}} initialized to a response defined by that protocol.
         </li>
     </ol>
     <h3>

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
       The API is designed to support the following goals:
     </p>
     <ul>
-      <li>Keep the act of requesting/issuance separate from the specific [=digital
+      <li>Keep the acts of requesting and issuance separate from the specific [=digital
       credential/protocol=], thereby enabling the extensibility of the
       [=digital credential/protocol=] and credential formats.
       </li>

--- a/index.html
+++ b/index.html
@@ -82,27 +82,31 @@
       credential/protocol=], thereby enabling the extensibility of the
       [=digital credential/protocol=] and credential formats.
       </li>
-      <li>Require [=digital credential/requests=] to be unencrypted, enabling
+      <li>Require [=digital credential/presentation requests=] and [=digital credential/issuance request=] to be unencrypted, enabling
       user-agent inspection for risk analysis.
       </li>
-      <li>Assume [=digital credential/presentation response|responses=] opacity
-      (encrypted responses), enabling verifiers and holders to control where
+      <li>Assume [=digital credential/presentation response=] and 
+      [=digital credential/issuance response=] opacity (encrypted responses), 
+      enabling issuers,  verifiers and holders to control where
       potentially sensitive personally identifiable information is exposed.
       </li>
       <li>Require [=transient activation=] to perform [=digital
-      credential/requests=], ensuring that sites cannot silently query for
+      credential/presentation requests=] or [=digital
+      credential/issuance request=], ensuring that sites cannot silently query for/offer
       digital credentials nor communicate with wallet providers without the
       user's active participation and confirmation of each action.
       </li>
       <li>Enable platform-provided credential selection UX when multiple wallet
-      applications have credentials that match a [=digital
-      credential/requests=].
+      applications have credentials that match [=digital
+      credential/presentation requests=] or an [=digital
+      credential/issuance request=].
       </li>
       <li>Enable platform-provided wallet selection UX when multiple wallet
         applications support the issuance request.
         </li>
       <li>Enable platforms to potentially provide secure cross-device [=digital
-      credential/requests=] with proximity checks.
+      credential/presentation requests=] and  [=digital
+      credential/issuance request=] with proximity checks.
       </li>
     </ul>
     <p id="credential-type-examples">
@@ -149,7 +153,7 @@
       </dd>
       <dt>
         <dfn data-dfn-for="digital credential" data-local-lt=
-        "requests">Presentation request</dfn>
+        "presentation requests">Presentation request</dfn>
       </dt>
       <dd>
         A presentation request is a request for a [=digital credential=]
@@ -166,12 +170,38 @@
       </dd>
       <dt>
         <dfn data-dfn-for="digital credential" data-local-lt=
-        "response">Presentation response</dfn>
+        "presentation response">Presentation response</dfn>
       </dt>
       <dd>
         A format that a [=holder|holder's=] software, such as a digital wallet,
         uses, via an [=digital credential/exchange protocol=], to respond to a
         [=digital credential/request data=] by a [=verifier=].
+      </dd>
+      <dt>
+        <dfn data-dfn-for="digital credential" data-local-lt=
+        "issuance request">Issuance request</dfn>
+      </dt>
+      <dd>
+        An issuance request is an offer to issue a [=digital credential=]
+        composed of an [=digital credential/credential offer=] and a [=digital
+        credential/exchange protocol=].
+      </dd>
+      <dt>
+        <dfn data-dfn-for="digital credential">credential offer</dfn>
+      </dt>
+      <dd>
+        A format that [=issuer=] software or a [=user agent=] uses, via an
+        [=digital credential/exchange protocol=], to offer issuing a [=digital
+        credential=] from an [=issuer=].
+      </dd>
+      <dt>
+        <dfn data-dfn-for="digital credential" data-local-lt=
+        "issuance response">Issuance response</dfn>
+      </dt>
+      <dd>
+        A format that a [=holder|holder's=] software, such as a digital wallet,
+        uses, via an [=digital credential/exchange protocol=], to respond to an
+        [=digital credential/credential offer=] by an [=issuer=].
       </dd>
       <dt>
         <dfn data-dfn-for="digital credential" data-local-lt=
@@ -327,6 +357,13 @@
     <h2>
       The `DigitalCredentialCreationOptions` dictionary
     </h2>
+    <p>
+      The {{DigitalCredentialRequest}} dictionary represents a [=digital
+      credential/issuance request=]. It is used to specify an [=digital
+      credential/exchange protocol=] and a [=digital credential/credential offer=],
+      which the user agent MAY forward to a software used by a holder, such as
+      a digital wallet.
+    </p>
     <pre class="idl">
     dictionary DigitalCredentialCreationOptions {
       required DOMString protocol;
@@ -350,9 +387,8 @@
       The `data` member
     </h3>
     <p>
-      <!-- TODO this isn't accurate, figure out how to phrase this -->
       The <dfn data-dfn-for="DigitalCredentialCreationOptions">data</dfn> member is the
-      [=digital credential/request data=] to be handled by the holder's
+      [=digital credential/credential offer=] to be handled by the holder's
       software, such as a digital wallet.
     </p>
     <h3>
@@ -455,8 +491,7 @@
           forthcoming.
         </aside>
       </li>
-      <!-- Figure out what should be returned here -->
-      <li>Return a {{DigitalCredential}}.
+      <li>Return a {{DigitalCredential}}. {{DigitalCredential/protocol}} is the protocol that was used to issue this credential. {{DigitalCredential/data}} is a response defined by the protocol.
       </li>
     </ol>
     <h3>

--- a/index.html
+++ b/index.html
@@ -568,7 +568,7 @@
       </p>
     </section>
     <h2 id="protocol-registry">
-      Registry of protocols for requesting digital credential
+      Registry of exchange protocols
     </h2>
     <p>
       The following is the registry of [=digital credential/exchange

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
       </li>
       <li>Assume opaque (i.e., encrypted) [=digital credential/presentation
       responses=] and [=digital credential/issuance responses=], enabling
-      issuers, verifiers and holders to control where potentially sensitive
+      issuers, verifiers, and holders to control where potentially sensitive
       personally identifiable information is exposed.
       </li>
       <li>Require [=transient activation=] to perform [=digital

--- a/index.html
+++ b/index.html
@@ -568,7 +568,7 @@
       </p>
     </section>
     <h2 id="protocol-registry">
-      Registry of exchange protocols
+      Registry of protocols
     </h2>
     <p>
       The following is the registry of [=digital credential/exchange

--- a/index.html
+++ b/index.html
@@ -311,9 +311,9 @@
       denotes the [=digital credential/exchange protocol=].
     </p>
     <p>
-      The {{DigitalCredentialCreateRequest/protocol}} member's value is be one
-      of the well-defined keys defined in [[[#protocol-registry]]] or any other
-      custom one.
+      The {{DigitalCredentialCreateRequest/protocol}} member's value can be one
+      of the well-defined protocol identifiers defined in [[[#protocol-registry]]] or a
+      custom protocol identifier.
     </p>
     <h3>
       The `data` member
@@ -321,7 +321,7 @@
     <p>
       The <dfn data-dfn-for="DigitalCredentialGetRequest">data</dfn> member is
       the [=digital credential/request data=] to be handled by the holder's
-      software, such as a digital wallet.
+      credential provider, such as a digital identity wallet.
     </p>
     <h2>
       Extensions to `CredentialCreationOptions` dictionary
@@ -388,7 +388,7 @@
     <p>
       The <dfn data-dfn-for="DigitalCredentialCreateRequest">data</dfn> member
       is the [=digital credential/request data=] to be handled by the holder's
-      software, such as a digital wallet.
+      credential provider, such as a digital identity wallet.
     </p>
     <h2>
       The `DigitalCredential` interface


### PR DESCRIPTION
Closes #167 

The following tasks have been completed:

- [ ] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/51492/)

Implementation commitment:

- [ ] WebKit (link to issue)
- [x] Chromium ([link to issue](https://crbug.com/378330032))
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/204.html" title="Last updated on May 1, 2025, 8:31 AM UTC (112e275)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/204/5592be0...112e275.html" title="Last updated on May 1, 2025, 8:31 AM UTC (112e275)">Diff</a>