### PR TITLE
Update Respec config with WG details

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     "use strict";
     // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
     var respecConfig = {
-      github: "WICG/digital-credentials",
+      github: "w3c-fedid/digital-credentials",
       editors: [
         {
           name: "Marcos Caceres",
@@ -36,8 +36,10 @@
       ],
       latestVersion: null,
       shortName: "digital-credentials",
-      specStatus: "CG-DRAFT",
-      group: "wicg",
+      specStatus: "ED",
+      edDraftURI: "https://w3c-fedid.github.io/digital-credentials/",
+      group: "fedid",
+      github: "https://github.com/w3c-fedid/digital-credentials",
       localBiblio: {},
       xref: {
         profile: "web-platform",


### PR DESCRIPTION
Updates existing metadata to match new home, and adds some missing options like GitHub URI and ED Draft URI. Also changes from CG report to Editor's Draft.

#205


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/217.html" title="Last updated on Apr 16, 2025, 5:29 PM UTC (33d6da3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/217/6ac3780...33d6da3.html" title="Last updated on Apr 16, 2025, 5:29 PM UTC (33d6da3)">Diff</a>