### PR TITLE
Fix links to request field to use the new format in the register inclusion criteria

### DIFF
--- a/index.html
+++ b/index.html
@@ -615,8 +615,12 @@
       <li>MUST define a representation, as either a [[WebIDL]] [=dictionary=]
       or a JSON object, of the [=digital credential/exchange protocol=] request
       structure (i.e., the [=dictionary=] which defines the semantics and
-      validation of the {{DigitalCredentialsProvider}}'s
-      {{DigitalCredentialsProvider/request}} member.
+      validation of the {{DigitalCredentialGetRequest}}'s
+      {{DigitalCredentialGetRequest/data}} member) and the [=digital
+      credential/issuance protocol=] request structure (i.e., the
+      [=dictionary=] which defines the semantics and validation of the
+      {{DigitalCredentialCreateRequest}}'s
+      {{DigitalCredentialCreateRequest/data}} member).
       </li>
       <li>MUST define a representation, as either a [[WebIDL]] [=dictionary=]
       or a JSON object, of the [=digital credential/exchange protocol=]


### PR DESCRIPTION
It also adds to text to cover both the presentation and issuance protocol.