### PR TITLE
Editoral: Link to registry inclusion criteria definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -679,7 +679,7 @@
         Define a protocol identifier
       </dt>
       <dd>
-        The protocol identifier MUST be a unique string that is not already in
+        The [=digital credentials registry/protocol identifier=] MUST be a unique string that is not already in
         use in the registry. Use only lowercase ASCII letters, digits, and
         hyphens (e.g., "protocol", "the-protocol"). The protocol identifier
         MUST uniquely define the set of required parameters and/or behavior
@@ -693,7 +693,7 @@
         Specify a protocol type
       </dt>
       <dd>
-        The protocol type is either "Presentation" for presentation protocols
+        The protocol [=digital credentials registry/type=] is either "Presentation" for presentation protocols
         used with `navigator.credentials.get` or "Issuance" for issuance
         protocols used with `navigator.credentials.create`.
       </dd>
@@ -708,7 +708,7 @@
         Provide a link to the specification
       </dt>
       <dd>
-        The specification MUST be a stable URL that points to the authoritative
+        The [=digital credentials registry/specification=] MUST be a stable URL that points to the authoritative
         source for the protocol, including validation rules.
       </dd>
     </dl>

--- a/index.html
+++ b/index.html
@@ -676,7 +676,7 @@
     </p>
     <dl>
       <dt>
-        Define a <dfn data-dfn-for="registry" data-local-lt="identifier">protocol identifier</dfn>
+        Define a <dfn data-dfn-for="registry" data-local-lt="identifier">protocol identifier</dfn>.
       </dt>
       <dd>
         The protocol identifier MUST be a unique string that is not already in
@@ -690,7 +690,7 @@
         identifier MUST be assigned and be added to the registry.
       </dd>
       <dt>
-        Specify a <dfn data-dfn-for="registry" data-local-lt="type">protocol type</dfn>
+        Specify a <dfn data-dfn-for="registry" data-local-lt="type">protocol type</dfn>.
       </dt>
       <dd>
         The protocol type is either "Presentation" for presentation protocols
@@ -698,14 +698,14 @@
         protocols used with `navigator.credentials.create`.
       </dd>
       <dt>
-        <dfn data-dfn-for="registry" data-local-lt="description">Describe the protocol</dfn>
+        <dfn data-dfn-for="registry" data-local-lt="description">Describe the protocol</dfn>.
       </dt>
       <dd>
         The description MUST be a brief summary of the protocol's purpose and
         use case.
       </dd>
       <dt>
-        Provide a <dfn data-dfn-for="registry" data-local-lt="link">link to the specification</dfn>
+        Provide a <dfn data-dfn-for="registry" data-local-lt="link">link to the specification</dfn>.
       </dt>
       <dd>
         The specification MUST be a stable URL that points to the authoritative

--- a/index.html
+++ b/index.html
@@ -676,10 +676,10 @@
     </p>
     <dl>
       <dt>
-        Define a protocol identifier
+        Define a <dfn data-dfn-for="registry" data-local-lt="identifier">protocol identifier</dfn>
       </dt>
       <dd>
-        The [=digital credentials registry/protocol identifier=] MUST be a unique string that is not already in
+        The protocol identifier MUST be a unique string that is not already in
         use in the registry. Use only lowercase ASCII letters, digits, and
         hyphens (e.g., "protocol", "the-protocol"). The protocol identifier
         MUST uniquely define the set of required parameters and/or behavior
@@ -690,25 +690,25 @@
         identifier MUST be assigned and be added to the registry.
       </dd>
       <dt>
-        Specify a protocol type
+        Specify a <dfn data-dfn-for="registry" data-local-lt="type">protocol type</dfn>
       </dt>
       <dd>
-        The protocol [=digital credentials registry/type=] is either "Presentation" for presentation protocols
+        The protocol type is either "Presentation" for presentation protocols
         used with `navigator.credentials.get` or "Issuance" for issuance
         protocols used with `navigator.credentials.create`.
       </dd>
       <dt>
-        Describe the protocol
+        <dfn data-dfn-for="registry" data-local-lt="description">Describe the protocol</dfn>
       </dt>
       <dd>
         The description MUST be a brief summary of the protocol's purpose and
         use case.
       </dd>
       <dt>
-        Provide a link to the specification
+        Provide a <dfn data-dfn-for="registry" data-local-lt="link">link to the specification</dfn>
       </dt>
       <dd>
-        The [=digital credentials registry/specification=] MUST be a stable URL that points to the authoritative
+        The specification MUST be a stable URL that points to the authoritative
         source for the protocol, including validation rules.
       </dd>
     </dl>
@@ -725,15 +725,16 @@
       <thead>
         <tr>
           <th>
-            <dfn data-dfn-for="digital credentials registry">Protocol
-            identifier</dfn>
+            [=registry/identifier|Protocol identifier=]
           </th>
           <th>
-            <dfn data-dfn-for="digital credentials registry">Type</dfn>
+            [=registry/Type=]
           </th>
           <th>
-            <dfn data-dfn-for=
-            "digital credentials registry">Specification</dfn>
+            [=registry/Description=]
+          </th>
+          <th>
+            [=registry/link|Specification=]
           </th>
         </tr>
       </thead>


### PR DESCRIPTION
Before this PR, the definitions were created but never linked it, which causes ReSpec warnings,


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/236.html" title="Last updated on May 28, 2025, 10:10 PM UTC (a39ef00)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/236/3d7ba96...a39ef00.html" title="Last updated on May 28, 2025, 10:10 PM UTC (a39ef00)">Diff</a>