### PR TITLE
Add a11y guidance for user agents

### DIFF
--- a/index.html
+++ b/index.html
@@ -963,8 +963,14 @@
       <h2>
         Accessibility Considerations
       </h2>
-      <p class="issue" title="Work in Progress">
-        This section is a work in progress as this document evolves.
+      <p>
+        [=User agents=] SHOULD mediate presentation and issuance requests in a
+        way that offers support for a wide range of user input methods, including
+        input hardware like keyboards, pointing devices, touch screens, voice
+        recognition, etc. Additionally, user agents SHOULD support accessible
+        output methods during these requests to ensure that prompts for
+        [=user consent=] during such requests can be meaningfully communicated to
+        the widest range of end-users.
       </p>
     </section>
     <section id="idl-index"></section>


### PR DESCRIPTION
This PR adds informative guidance to user agents encouraging them to mediate presentation and issuance requests in a way that supports a wide range of accessible inputs and outputs.

The intent is to submit this content in the horizontal review request to the [a11y-request repo](https://github.com/w3c/a11y-request).

Partially closes #229

The following tasks have been completed:

- [ ] Modified Web platform tests (link)

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev
 
