### PR TITLE
Fix discovery typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -563,7 +563,7 @@
       whose value is "digital".
     </p>
     <h3>
-      [[\discovey]] internal slot
+      [[\discovery]] internal slot
     </h3>
     <p>
       The {{DigitalCredential}} [=interface object=] has an internal slot named


### PR DESCRIPTION
I hope this is just a spec typo


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/johannhof/digital-credentials/pull/261.html" title="Last updated on Jun 6, 2025, 8:45 PM UTC (2ca24aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/261/ee172e6...johannhof:2ca24aa.html" title="Last updated on Jun 6, 2025, 8:45 PM UTC (2ca24aa)">Diff</a>