### PR TITLE
Formally define 'protocol identifier'

### DIFF
--- a/index.html
+++ b/index.html
@@ -708,7 +708,7 @@
         Define a [=digital credential/protocol identifier=].
       </dt>
       <dd>
-        The [=digital credential/Protocol identifier=] MUST be a unique string that is not already in
+        The [=digital credential/protocol identifier=] MUST be a unique string that is not already in
         use in the registry. The [=digital credential/Protocol identifier=]
         MUST uniquely define the set of required parameters and/or behavior
         that a digital credential provider implementation needs to support to

--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@
       <dd>
         A [=string=] composed of one or more [=ASCII lower alpha=] [=code
         points=], zero or more U+002D HYPHEN-MINUS [=code points=], and zero or
-        more [=ASCII digit=] [=code points=].
+        more [=ASCII digit=] [=code points=] (in any order). For example, "123a-protocol", "abc", or simply "a".
       </dd>
       <dt>
         <dfn data-dfn-for="digital credential" data-local-lt=

--- a/index.html
+++ b/index.html
@@ -709,8 +709,7 @@
       </dt>
       <dd>
         The protocol identifier MUST be a unique string that is not already in
-        use in the registry. Use only lowercase ASCII letters, digits, and
-        hyphens (e.g., "protocol", "the-protocol"). The protocol identifier
+        use in the registry. The protocol identifier
         MUST uniquely define the set of required parameters and/or behavior
         that a digital credential provider implementation needs to support to
         successfully handle the request. If the set of required parameters or

--- a/index.html
+++ b/index.html
@@ -236,17 +236,28 @@
         "exchange protocol">Exchange protocol</dfn>
       </dt>
       <dd>
-        A protocol used for exchanging a [=digital credential=] between a
-        [=holder=] and a [=verifier=]. See section [[[#protocol-registry]]].
+        A standardized protocol used for exchanging a [=digital credential=]
+        between a [=holder=] and a [=verifier=]. A protocol is identified by a
+        [=digital credential/protocol identifier=]. See section also
+        [[[#protocol-registry]]].
+      </dd>
+      <dt>
+        <dfn data-dfn-for="digital credential">Protocol identifier</dfn>
+      </dt>
+      <dd>
+        A [=string=] composed of one or more [=ASCII lower alpha=] [=code
+        points=], zero or more U+002D HYPHEN-MINUS [=code points=], and zero or
+        more [=ASCII digit=] [=code points=].
       </dd>
       <dt>
         <dfn data-dfn-for="digital credential" data-local-lt=
         "issuance protocol">Issuance protocol</dfn>
       </dt>
       <dd>
-        A protocol used for communication between an [=issuer=] and a
-        [=holder=] during the issuance of a [=digital credential=]. See section
-        [[[#protocol-registry]]].
+        A standardized protocol used for communication between an [=issuer=]
+        and a [=holder=] during the issuance of a [=digital credential=]. The
+        issuance protocol is identified by a [=digital credential/protocol
+        identifier=]. See also section [[[#protocol-registry]]].
       </dd>
     </dl>
     <h2>
@@ -694,8 +705,7 @@
     </p>
     <dl>
       <dt>
-        Define a <dfn data-dfn-for="registry" data-local-lt=
-        "identifier">protocol identifier</dfn>.
+        Define a [=digital credential/protocol identifier=].
       </dt>
       <dd>
         The protocol identifier MUST be a unique string that is not already in
@@ -746,7 +756,7 @@
       <thead>
         <tr>
           <th>
-            [=registry/identifier|Protocol identifier=]
+            [=digital credential/Protocol identifier=]
           </th>
           <th>
             [=registry/Type=]

--- a/index.html
+++ b/index.html
@@ -708,8 +708,8 @@
         Define a [=digital credential/protocol identifier=].
       </dt>
       <dd>
-        The protocol identifier MUST be a unique string that is not already in
-        use in the registry. The protocol identifier
+        The [=digital credential/Protocol identifier=] MUST be a unique string that is not already in
+        use in the registry. The [=digital credential/Protocol identifier=]
         MUST uniquely define the set of required parameters and/or behavior
         that a digital credential provider implementation needs to support to
         successfully handle the request. If the set of required parameters or

--- a/index.html
+++ b/index.html
@@ -709,7 +709,7 @@
       </dt>
       <dd>
         The [=digital credential/protocol identifier=] MUST be a unique string that is not already in
-        use in the registry. The [=digital credential/Protocol identifier=]
+        use in the registry. The [=digital credential/protocol identifier=]
         MUST uniquely define the set of required parameters and/or behavior
         that a digital credential provider implementation needs to support to
         successfully handle the request. If the set of required parameters or


### PR DESCRIPTION
Closes #270


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/276.html" title="Last updated on Jun 22, 2025, 9:19 AM UTC (99f4eff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/276/05d0766...99f4eff.html" title="Last updated on Jun 22, 2025, 9:19 AM UTC (99f4eff)">Diff</a>