### PR TITLE
Clean up privacy considerations TODO sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -1141,54 +1141,6 @@
       </section>
       <section>
         <h3>
-          Individual Consent
-        </h3>
-        <p class="issue" title="Work in progress">
-          Explain how the API acquires an individual's consent to share a
-          digital credential and how digital wallets can also provide further
-          consent when sharing information.
-        </p>
-      </section>
-      <section>
-        <h3>
-          Data Retention
-        </h3>
-        <p class="issue" title="Work in progress">
-          Explain how verifiers might retain data and what the ecosystem does
-          to mitigate excessive data retention policies.
-        </p>
-      </section>
-      <section>
-        <h3>
-          Compliance with Privacy Regulations
-        </h3>
-        <p class="issue" title="Work in progress">
-          Explain to what extent the API complies with known privacy
-          regulations (e.g., consent) and what parts of those regulations are
-          not possible to enforce via the API (e.g., retention).
-        </p>
-      </section>
-      <section>
-        <h3>
-          Selective and Unlinkable Disclosure
-        </h3>
-        <p class="issue" title="Work in progress">
-          Explain how selective disclosure and unlinkable disclosure help
-          preserve privacy as well as their limitations in doing so.
-        </p>
-      </section>
-      <section>
-        <h3>
-          Phoning Home
-        </h3>
-        <p class="issue" title="Work in progress">
-          Explain how some systems might "phone home", the impact on privacy
-          that might have, and what the ecosystem provides to mitigate the
-          risk.
-        </p>
-      </section>
-      <section>
-        <h3>
           User Permission and Transparency
         </h3>
         <p class="issue" title="Work in progress"></p>


### PR DESCRIPTION
These have been incorporated into other sections:

- Regulation / consent in #253 and #260
- Data retention is touched on in #260 when we talk about encryption, otherwise is, in my opinion, not something we should cover as it is out of scope of the DC API and even protocols.
- Selective disclosure / unlinkability are covered in #260
- Phoning home is covered in #260

(They're not perfect and some of them link to follow-up discussions, but it's confusing having those TODO sections as well)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/johannhof/digital-credentials/pull/285.html" title="Last updated on Jun 22, 2025, 6:44 AM UTC (1e284e5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/285/93634a3...johannhof:1e284e5.html" title="Last updated on Jun 22, 2025, 6:44 AM UTC (1e284e5)">Diff</a>