### PR TITLE
Add Contributors section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1899,5 +1899,24 @@
     </section>
     <section id="idl-index"></section>
     <section id="conformance"></section>
+
+    <section id="contributors">
+      <h2>Contributors</h3>
+      <p>
+        Thank you to the following individuals for their valuable feedback and contributions to
+        this specification:
+      </p>
+      <ul>
+        <li>Chris Wilson</li>
+        <li>Dominique Hazael-Massieux (W3C)</li>
+        <li>Johann Hofmann (Google)</li>
+        <li>Manu Sporny (Digital Bazaar)</li>
+        <li>Orie Steele (Transmute)</li>
+        <li>Rick Byers (Google)</li>
+        <li>Simone Onofri (W3C)</li>
+        <li>Theresa O'Connor</li>
+        <li>Wendy Seltzer</li>
+      </ul>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
This PR adds a new Contributors section to the spec. It's a basic `<ul>` list of people to give us finer control over who is included. I tried leveraging [ReSpec's `gh-contributors` feature](https://respec.org/docs/#id-gh-contributors) to automate pulling the list of contributors from GitHub, but the list included existing and former editors (which felt redundant), and it won't give us any control to omit people who (we) may not wish to include as a contributor for IPR reasons, etc...

The list of people was generated via `git shortlog --summary` as of branching (https://github.com/w3c-fedid/digital-credentials/commit/4624c60ce71117e0debe240c03ba9c997038466e.) I tried my best to associate people to their respective organizations, but I'll need some help from @wseltzer and @cwilso to identify with which orgs they might want their contribution to be associated with. 

Closes #311.

The following tasks have been completed:

- [ ] Modified Web platform tests (link)

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev
 
