### PR TITLE
Mark `requests` as required in DigitalCredentialCreationOptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -523,7 +523,7 @@
     </h3>
     <pre class="idl">
     dictionary DigitalCredentialCreationOptions {
-      sequence&lt;DigitalCredentialCreateRequest&gt; requests;
+      required sequence&lt;DigitalCredentialCreateRequest&gt; requests;
     };
     </pre>
     <h4>


### PR DESCRIPTION
Closes #319 

Similar to presentation, requests should be required in issuance request as well.

The following tasks have been completed:

- [X] Modified Web platform tests (https://github.com/web-platform-tests/wpt/pull/53925)

Implementation commitment:

- [x] WebKit (link to issue)
- [x] Chromium (https://crbug.com/433704947)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/318.html" title="Last updated on Jul 27, 2025, 9:17 AM UTC (4efb9d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/318/385ee13...4efb9d2.html" title="Last updated on Jul 27, 2025, 9:17 AM UTC (4efb9d2)">Diff</a>