### PR TITLE
Editorial: move examples to own section

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,6 +181,121 @@
       Cases</a>
       </li>
     </ul>
+    <section class="informative">
+      <h2>
+        Examples of usage
+      </h2>
+      <p>
+        The following examples illustrate how the Digital Credentials API can
+        be used to request and issue digital credentials.
+      </p>
+      <h3>
+        Requesting a digital credential
+      </h3>
+      <p>
+        The following example shows how to request a digital credential using
+        the Digital Credentials API. The entry point for the API is the
+        `navigator.credentials.`{{CredentialsContainer/get()}} method, which is
+        used to request a [=digital credential=] from the user agent. If the
+        user agent supports [=digital credential/presentation
+        requests|presentation=], it allows the user to select a digital
+        credential through a [=credential chooser=]:
+      </p>
+      <pre class="example html" title="Requesting a digital credential">
+        &lt;button&gt;Verify Identity&lt;/button&gt;
+        &lt;script&gt;
+          const button = document.querySelector("button");
+          button.addEventListener("click", async () =&gt; {
+            try {
+              const credential = await navigator.credentials.get({
+                digital: {
+                  requests: [{
+                    protocol: "example-protocol",
+                    data: { /* request data */ }
+                  }]
+                }
+              });
+
+              // Post it back to the server for decryption and verification
+              const response = await fetch("/verify-credential", {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json"
+                },
+                body: JSON.stringify(credential, null, 2)
+              });
+
+              // Check response
+              if (!response.ok) {
+                throw new Error("Failed to verify credential");
+              }
+
+              // Render the verification result
+              displayVerificationResult(await response.json());
+
+            } catch (error) {
+              console.error("Error requesting digital credential:", error);
+            }
+          });
+        &lt;/script&gt;
+      </pre>
+      <p>
+        Simliarly, when a site needs to [=digital credential/issuance|issue=] a
+        digital credential, the Digital Credentials API mediates the issuance
+        of a digital credential between the site, the user agent, and the
+        [=holder=].
+      </p>
+      <h3>
+        Issuing a digital credential
+      </h3>
+      <p>
+        The following example shows how to request the issuance of a digital
+        credential using the Digital Credentials API. To issue a digital
+        credential, a site calls the
+        `navigator.credentials.`{{CredentialsContainer/create()}} method,
+        which, if the user agent supports issuance, would initiate the issuance
+        flow:
+      </p>
+      <pre class="example html" title=
+      "Requesting issuance of a digital credential">
+        &lt;button&gt;Request Digital Credential Issuance&lt;/button&gt;
+        &lt;script&gt;
+          const button = document.querySelector("button");
+          button.addEventListener("click", async () =&gt; {
+            try {
+              const credential = await navigator.credentials.create({
+                digital: {
+                  requests: [{
+                    protocol: "example-issuance-protocol",
+                    data: { /* issuance request data */ }
+                  }]
+                }
+              });
+            } catch (error) {
+              console.error("Error issuing digital credential:", error);
+            }
+          });
+        &lt;/script&gt;
+      </pre>
+      <h3>
+        Requesting a digital credential across origins
+      </h3>
+      <p>
+        The specification allows usage of the API from a remote/third-party
+        origin via the <a>"digital-credentials-get"</a> Permissions Policy.
+        This is useful for scenarios where a website wants to request digital
+        credentials from a wallet provider that is hosted on a different
+        origin. The Permissions Policy can be set on an iframe that embeds the
+        website that wants to use the API. Here is an example of how the
+        Permissions Policy can be set on an iframe:
+      </p>
+      <pre class="example html" title=
+      "Requesting a digital credential across origins">
+        &lt;iframe src="https://wallet-provider.example.com"
+                allow="digital-credentials-get"&gt;
+        &lt;/iframe&gt;
+      </pre>
+    </section>
     <h2>
       Model
     </h2>
@@ -350,91 +465,6 @@
       Please see [[[#credential-management-integration]]] for complete details
       of how to integrate with the [[[credential-management]]] specification.
     </p>
-    <aside class="example" title="Requesting a digital credential">
-      <p>
-        The following example shows how to request a digital credential using
-        the Digital Credentials API. The entry point for the API is the
-        `navigator.credentials.`{{CredentialsContainer/get()}} method, which is
-        used to request a [=digital credential=] from the user agent. If the
-        user agent supports [=digital credential/presentation
-        requests|presentation=], it allows the user to select a digital
-        credential through a [=credential chooser=]:
-      </p>
-      <pre class="html">
-        &lt;button&gt;Verify Identity&lt;/button&gt;
-        &lt;script&gt;
-          const button = document.querySelector("button");
-          button.addEventListener("click", async () =&gt; {
-            try {
-              const credential = await navigator.credentials.get({
-                digital: {
-                  requests: [{
-                    protocol: "example-protocol",
-                    data: { /* request data */ }
-                  }]
-                }
-              });
-
-              // Post it back to the server for decryption and verification
-              const response = await fetch("/verify-credential", {
-                method: "POST",
-                headers: {
-                  "Content-Type": "application/json"
-                },
-                body: JSON.stringify(credential, null, 2)
-              });
-
-              // Check response
-              if (!response.ok) {
-                throw new Error("Failed to verify credential");
-              }
-
-              // Render the verification result
-              displayVerificationResult(await response.json());
-
-            } catch (error) {
-              console.error("Error requesting digital credential:", error);
-            }
-          });
-        &lt;/script&gt;
-      </pre>
-    </aside>
-    <p>
-      Simliarly, when a site needs to [=digital credential/issuance|issue=] a
-      digital credential, the Digital Credentials API mediates the issuance of
-      a digital credential between the site, the user agent, and the
-      [=holder=].
-    </p>
-    <aside class="example" title="Issuing a digital credential">
-      <p>
-        The following example shows how to request the issuance of a digital
-        credential using the Digital Credentials API. To issue a digital
-        credential, a site calls the
-        `navigator.credentials.`{{CredentialsContainer/create()}} method,
-        which, if the user agent supports issuance, would initiate the issuance
-        flow:
-      </p>
-      <pre class="html">
-        &lt;button&gt;Request Digital Credential Issuance&lt;/button&gt;
-        &lt;script&gt;
-          const button = document.querySelector("button");
-          button.addEventListener("click", async () =&gt; {
-            try {
-              const credential = await navigator.credentials.create({
-                digital: {
-                  requests: [{
-                    protocol: "example-issuance-protocol",
-                    data: { /* issuance request data */ }
-                  }]
-                }
-              });
-            } catch (error) {
-              console.error("Error issuing digital credential:", error);
-            }
-          });
-        &lt;/script&gt;
-      </pre>
-    </aside>
     <h3>
       Extensions to `CredentialRequestOptions` dictionary
     </h3>


### PR DESCRIPTION
Move the examples to their own section, add permission policy example to the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/324.html" title="Last updated on Aug 1, 2025, 4:59 AM UTC (1baabb2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/324/d2b2c56...1baabb2.html" title="Last updated on Aug 1, 2025, 4:59 AM UTC (1baabb2)">Diff</a>