### PR TITLE
Editorial: Fix mislabeling of section intended for non-government credentials

### DIFF
--- a/index.html
+++ b/index.html
@@ -1755,7 +1755,7 @@
           further attacks on the affected individual.
         </p>
         <h5>
-          Risk of proliferation of requests for government credentials
+          Risk of proliferation of requests for non-government credentials
         </h5>
         <p>
           The flexibility and lack of regulation of non-government credentials


### PR DESCRIPTION
This is a [correction class 2 change](https://www.w3.org/policies/process/#class-2).

The section title [9.4.2.2 Risk of proliferation of requests for government credentials](https://w3c-fedid.github.io/digital-credentials/#risk-of-proliferation-of-requests-for-government-credentials-0) should read "non-government" instead of "government" (as it is a subsection of [9.4.2 Non-government-issued credentials](https://w3c-fedid.github.io/digital-credentials/#non-government-issued-credentials)).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/csarven/digital-credentials/pull/336.html" title="Last updated on Aug 11, 2025, 3:29 AM UTC (9ff4c51)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/336/e531585...csarven:9ff4c51.html" title="Last updated on Aug 11, 2025, 3:29 AM UTC (9ff4c51)">Diff</a>