### PR TITLE
Editorial: mark some sections as informative

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
     <section id="sotd"></section><!--
     // MARK: Introduction
     -->
-    <h2>
+    <h2 class="informative">
       Introduction
     </h2>
     <p>
@@ -315,8 +315,7 @@
                 allow="digital-credentials-create"&gt;
         &lt;/iframe&gt;
       </pre>
-    </section>
-    <h2>
+    <h2 class="informative">
       Scope
     </h2>
     <p>


### PR DESCRIPTION
The introduction and the scope sections should be marked as non-normative.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/347.html" title="Last updated on Aug 15, 2025, 5:30 AM UTC (8973f87)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/347/fb88564...8973f87.html" title="Last updated on Aug 15, 2025, 5:30 AM UTC (8973f87)">Diff</a>