### PR TITLE
chore: bring back the missing </section> tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,6 +315,7 @@
                 allow="digital-credentials-create"&gt;
         &lt;/iframe&gt;
       </pre>
+    </section>  
     <h2 class="informative">
       Scope
     </h2>


### PR DESCRIPTION
It was deleted by mistake in https://github.com/w3c-fedid/digital-credentials/pull/347/files

 
