### PR TITLE
Remove redundant text in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1575,8 +1575,7 @@
           against dangerous content and permission requests on the Web and
           could intervene on their behalf, proactively rejecting requests or
           requiring pre-authorization. To support this, the Digital Credentials
-          API requires that credential requests be readable by the [=user API
-          requires credential requests to be readable by the [=user agent=]
+          API requires credential requests to be readable by the [=user agent=]
           (i.e., not end-to-end encrypted to the [=verifier=]).
           </li>
           <li>[=issuers=] and lawmakers might decide to restrict use of


### PR DESCRIPTION
Remove apparently redundant (duplicate) text.

Closes (no issue to be closed - just correcting a typo).

The following tasks have been completed:

- [ ] Modified Web platform tests (link)

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/matatk/digital-credentials/pull/362.html" title="Last updated on Aug 26, 2025, 9:41 PM UTC (4e27988)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/362/af86d79...matatk:4e27988.html" title="Last updated on Aug 26, 2025, 9:41 PM UTC (4e27988)">Diff</a>