### PR TITLE
chore: temporary removing validating links

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: w3c/spec-prod@v2
         with:
           TOOLCHAIN: respec
-          VALIDATE_LINKS: true
+          VALIDATE_LINKS: false
           VALIDATE_PUBRULES: false
           GH_PAGES_BRANCH: gh-pages
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}


### PR DESCRIPTION
Analyzing the artifacts reveals some fragments, a robots.txt, and a circular reference. 

I want to check on the final URL.