### PR TITLE
Introduce "active promise" concept for request coordinator.

### DIFF
--- a/index.html
+++ b/index.html
@@ -486,6 +486,14 @@
         [=digital credential/presentation request=] by a [=verifier=].
       </dd>
       <dt>
+        <dfn data-dfn-for="digital credential" data-local-lt=
+        "credential response">Credential response</dfn>
+      </dt>
+      <dd>
+        A [=digital credential/presentation response=] or an [=digital
+        credential/issuance response=].
+      </dd>
+      <dt>
         <dfn data-for="digital credential">Credential request</dfn>
       </dt>
       <dd>
@@ -569,22 +577,15 @@
       coordinator/interaction states=].
     </p>
     <p>
-      The [=credential request coordinator=] has an <dfn data-dfn-for=
-      "credential request coordinator">active promise</dfn> that is initially
-      `null`. This {{Promise}} represents the current [=credential request=] in
-      progress, if any.
-    </p>
-    <p>
-      A user agent MAY delegate some or all coordinator responsibilities to
-      external wallet applications, platform components, or other trusted
-      entities according to user or platform policy.
-    </p>
-    <p>
-      The coordinator manages the lifecycle of the interaction's [=credential
-      request coordinator/active promise=] and its associated {{AbortSignal}}
-      (if any), including resolution with the user's selected [=digital
-      credential=] or the [=holder=]'s response, or [=reject|rejection=] due to
-      errors or the user or program aborting the [=credential request=].
+      The [=credential request coordinator=] maintains an <dfn data-dfn-for=
+      "credential request coordinator">active promise</dfn>, which the user
+      agent initializes as `null`. Through this {{Promise}}, the
+      [=coordinator=] reflects the state of the asynchronous [=credential
+      request=] workflow to script and either [=resolves=] with a [=digital
+      credential/credential response=] when the interaction completes
+      successfully, or [=rejects=] when processing fails, when the user cancels
+      the request via the UI, or when script aborts the operation via an
+      {{AbortSignal}}.
     </p>
     <p>
       The [=credential request coordinator=]:
@@ -598,11 +599,16 @@
       is determined by matching the request parameters, user consent, and
       platform policy.
       </li>
-      <li>[=Resolves=] the interaction's {{Promise}} with the selected
-      [=digital credential=] or [=holder=]'s response, or [=rejects=] it to
-      indicate that the [=credential request=] was aborted.
+      <li>Manages [=resolve|resolution=] or [=reject|rejection=] of the
+      [=credential request coordinator/active promise=] based on the
+      interaction outcome.
       </li>
     </ul>
+    <p>
+      A user agent MAY delegate some or all coordinator responsibilities to
+      external wallet applications, platform components, or other trusted
+      entities according to user or platform policy.
+    </p>
     <aside class="note">
       <p>
         Although the coordinator handles input/output coordination, it is the


### PR DESCRIPTION
The active promise is used in conjunction with upcoming algorithms. It's the promise that ultimately gets resolved with the digital credential or otherwise rejected.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/417.html" title="Last updated on Jan 7, 2026, 8:13 AM UTC (f66ef8f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/417/b3d3a79...f66ef8f.html" title="Last updated on Jan 7, 2026, 8:13 AM UTC (f66ef8f)">Diff</a>