### PR TITLE
Define "present credential requests" algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1087,8 +1087,8 @@
         <ol>
           <li>Let |error| be a newly created {{"AbortError"}} {{DOMException}}.
           </li>
-          <li>[=credential request coordinator/Reject request with=] |error|
-          and |promise|.
+          <li>[=credential request coordinator/reject the credential request
+          with=] |error| and |promise|.
           </li>
           <li>Return.
           </li>
@@ -1124,8 +1124,8 @@
               </dd>
             </dl>
           </li>
-          <li>[=credential request coordinator/Reject request with=] |error|
-          and |promise|.
+          <li>[=credential request coordinator/reject the credential request
+          with=] |error| and |promise|.
           </li>
           <li>Return.
           </li>
@@ -1148,8 +1148,8 @@
           </li>
           <li>If |parsedDataOrError| is an [=exception=]:
             <ol>
-              <li>[=credential request coordinator/Reject request with=] |parsedDataOrError|
-              and |promise|.
+              <li>[=credential request coordinator/reject the credential
+              request with=] |parsedDataOrError| and |promise|.
               </li>
               <li>Return.
               </li>
@@ -1159,8 +1159,8 @@
             <ol>
               <li>Let |error| be a newly created {{TypeError}}.
               </li>
-              <li>[=credential request coordinator/Reject request with=] |error|
-              and |promise|.
+              <li>[=credential request coordinator/reject the credential
+              request with=] |error| and |promise|.
               </li>
               <li>Return.
               </li>
@@ -1183,9 +1183,8 @@
               request coordinator/active promise=] is not |promise|, then
               return.
               </li>
-              <li>Let |abortSignal| be the [=credential request
-              coordinator=]'s [=credential request coordinator/abort
-              signal=].
+              <li>Let |abortSignal| be the [=credential request coordinator=]'s
+              [=credential request coordinator/abort signal=].
               </li>
               <li>Let |abortAlgorithm| be the [=credential request
               coordinator=]'s [=credential request coordinator/abort

--- a/index.html
+++ b/index.html
@@ -1132,6 +1132,9 @@
       </li>
       <li>If a [=digital credential=] was selected by the user:
         <ol>
+          <li>Let |selectedRequest| be the item in |validatedRequests| that was
+          used to invoke the [=holder=] for this exchange.
+          </li>
           <li>Let |responseData| be a [=string=] [=digital
           credential/presentation response=] or [=string=] [=digital
           credential/issuance response=] returned by the [=holder=].
@@ -1166,8 +1169,8 @@
             </ol>
           </li>
           <li>Let |protocol:DigitalCredentialProtocol| be the [=enumeration
-          value=] of the [=digital credential/protocol identifier=] used in the
-          exchange.
+          value=] of |selectedRequest|'s [=digital credential/protocol
+          identifier=].
           </li>
           <li>Let |credential| be a newly created {{DigitalCredential}}
           instance with its {{DigitalCredential/data}} initialized to

--- a/index.html
+++ b/index.html
@@ -1053,14 +1053,14 @@
       |documentOrigin|.
       </li>
       <li>Present a [=digital credential chooser=] with |requestData| and wait
-      for the user to either:
+        for the user to do one of the following:
         <ul>
           <li>Select a [=digital credential=] and [=holder=] that can fulfill
-          the request,
+            the request.
           </li>
-          <li>Cancel the operation,
+          <li>Cancel the operation.
           </li>
-          <li>Abort the operation via |signal|, or
+          <li>Abort the operation via |signal|.
           </li>
           <li>Encounter a platform-specific error.
           </li>

--- a/index.html
+++ b/index.html
@@ -581,9 +581,9 @@
         <dfn>Digital credential chooser</dfn>
       </dt>
       <dd>
-        A user agent-provided user interface that presents one or more
+        A platform-provided user interface that presents one or more
         [=digital credential/credential requests=] to the user, allowing them
-        to select a [=digital credential=] and [=holder=] that can fulfill the
+        to select a [=digital credential=] or [=holder=] that can fulfill the
         request, or cancel the operation.
         <aside class="note" title="Relationship to credential chooser">
           The [=digital credential chooser=] may be invoked as part of a
@@ -1073,12 +1073,10 @@
       <li>Present a [=digital credential chooser=] with |requestData| and wait
         for the user to do one of the following:
         <ul>
-          <li>Select a [=digital credential=] and [=holder=] that can fulfill
+          <li>Select a [=digital credential=] or [=holder=] that can fulfill
             the request.
           </li>
           <li>Cancel the operation.
-          </li>
-          <li>Abort the operation via |signal|.
           </li>
           <li>Encounter a platform-specific error.
           </li>
@@ -1098,7 +1096,7 @@
       </li>
       <li>If the user cancels the operation or no credential was selected:
         <ol>
-          <li>Let |error| be a newly created {{"AbortError"}} {{DOMException}}.
+          <li>Let |error| be a newly created {{"NotAllowedError"}} {{DOMException}}.
           </li>
           <li>[=credential request coordinator/reject the credential request
           with=] |error| and |promise|.

--- a/index.html
+++ b/index.html
@@ -1530,6 +1530,16 @@
       </dt>
       <dd>
         An [=origin=].
+        <p class="note" title=
+        "Why both origins are included in the request context">
+          The [=request context/document origin=] can differ from the [=request
+          context/top origin=] when the API is called from a cross-origin
+          [^iframe^] (e.g., an embedded verification service). Including both
+          origins allows the [=digital credential chooser=] and [=holder=] to
+          make informed trust decisions about which party is actually
+          requesting the credential, not just which top-level site is hosting
+          the request.
+        </p>
       </dd>
     </dl>
     <h4>

--- a/index.html
+++ b/index.html
@@ -1165,9 +1165,9 @@
               </li>
             </ol>
           </li>
-          <li>Let |protocol:DigitalCredentialProtocol| be the
-          {{DigitalCredentialProtocol}} [=enumeration value=] that matches the
-          [=digital credential/protocol identifier=] used in the exchange.
+          <li>Let |protocol:DigitalCredentialProtocol| be the [=enumeration
+          value=] of the [=digital credential/protocol identifier=] used in the
+          exchange.
           </li>
           <li>Let |credential| be a newly created {{DigitalCredential}}
           instance with its {{DigitalCredential/data}} initialized to

--- a/index.html
+++ b/index.html
@@ -1041,13 +1041,13 @@
     </h3>
     <p>
       To <dfn data-dfn-for="credential request coordinator">present the
-      credential request</dfn> given a [=Document=] |document|, a [=sequence=]
-      of validated credential requests |validatedRequests|, a {{Promise}}
+      credential request</dfn> given a [=Document=] |document|, a [=list=] of
+      validated credential requests |validatedRequests|, a {{Promise}}
       |promise:Promise|, and an optional {{AbortSignal}} |signal|:
     </p>
     <ol class="algorithm">
-      <li>Let |topOrigin| be |document|'s [=relevant settings object=]'s
-      [=environment settings object/origin=].
+      <li>Let |topOrigin| be |document|'s [=top-level traversable=]'s
+      [=navigable/active document=]'s [=Document/origin=].
       </li>
       <li>Let |documentOrigin| be |document|'s [=Document/origin=].
       </li>

--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
         used to request a [=digital credential=] from the user agent. If the
         user agent supports [=digital credential/presentation
         requests|presentation=], it allows the user to select a digital
-        credential through a [=credential chooser=]:
+        credential through a [=digital credential chooser=]:
       </p>
       <pre class="example html" title="Requesting a digital credential">
         &lt;button&gt;Verify Identity&lt;/button&gt;
@@ -556,6 +556,20 @@
       <dd>
         See [=credential request coordinator=].
       </dd>
+      <dt>
+        <dfn>Digital credential chooser</dfn>
+      </dt>
+      <dd>
+        A user agent-provided user interface that presents one or more
+        [=digital credential/credential requests=] to the user, allowing them
+        to select a [=digital credential=] and [=holder=] that can fulfill the
+        request, or cancel the operation.
+        <aside class="note" title="Relationship to credential chooser">
+          The [=digital credential chooser=] may be invoked as part of a
+          broader [=credential chooser=], or as a separate platform-provided
+          user interface. The exact relationship is implementation-defined.
+        </aside>
+      </dd>
     </dl><!--
     // MARK: Protocols
     -->
@@ -853,7 +867,7 @@
         </ol>
       </li>
       <li>[=credential request coordinator/Present the credential request=]
-      with |document|, |validatedRequests|, and |signal|.
+      with |document|, |validatedRequests|, |promise|, and |signal|.
       </li>
       <li>If |document| stops being [=Document/fully active=], [=credential
       request coordinator/abort the credential request=] with an
@@ -960,10 +974,10 @@
           coordinator/interaction state=] to "[=credential request
           coordinator/aborting=]".
           </li>
-          <li>Dismiss the [=credential chooser=].
+          <li>Dismiss the [=digital credential chooser=].
             <p class="note">
-              Dismissal can fail (e.g., if the [=credential chooser=] was
-              destroyed due to memory pressure), but the [=coordinator=]
+              Dismissal can fail (e.g., if the [=digital credential chooser=]
+              was destroyed due to memory pressure), but the [=coordinator=]
               proceeds to complete the credential request regardless.
             </p>
           </li>
@@ -1020,19 +1034,187 @@
           </li>
         </ol>
       </li>
-    </ol>
+    </ol><!--
+    // MARK: Present the credential request
+    -->
     <h3>
       Present the credential request
     </h3>
     <p>
-      <dfn data-dfn-for="credential request coordinator">Present the credential
-      request</dfn> to be written.
+      To <dfn data-dfn-for="credential request coordinator">present the
+      credential request</dfn> given a [=Document=] |document|, a [=sequence=]
+      of validated credential requests |validatedRequests|, a {{Promise}}
+      |promise:Promise|, and an optional {{AbortSignal}} |signal|:
     </p>
-    <aside class="issue">
-      See <a href=
-      "https://github.com/w3c-fedid/digital-credentials/pull/419">Pull request
-      #419</a>.
-    </aside><!--
+    <ol class="algorithm">
+      <li>Let |topOrigin| be |document|'s [=relevant settings object=]'s
+      [=environment settings object/origin=].
+      </li>
+      <li>Let |documentOrigin| be |document|'s [=Document/origin=].
+      </li>
+      <li>Let |requestData| be a new [=request context=] whose [=request
+      context/requests=] is |validatedRequests|, [=request context/top origin=]
+      is |topOrigin|, and [=request context/document origin=] is
+      |documentOrigin|.
+      </li>
+      <li>Present a [=digital credential chooser=] with |requestData| and wait
+      for the user to either:
+        <ul>
+          <li>Select a [=digital credential=] and [=holder=] that can fulfill
+          the request,
+          </li>
+          <li>Cancel the operation,
+          </li>
+          <li>Abort the operation via |signal|, or
+          </li>
+          <li>Encounter a platform-specific error.
+          </li>
+        </ul>
+        <aside class="issue" data-number="456"></aside>
+      </li>
+      <li>If |signal| was passed and |signal| is [=AbortSignal/aborted=]:
+        <ol>
+          <li>Return.
+            <p class="note" title="Abort already handled">
+              The algorithm [=AbortSignal/add|added=] to |signal| by the
+              [=credential request coordinator/prepare credential requests=]
+              steps handle tearing down the [=digital credential chooser=].
+            </p>
+          </li>
+        </ol>
+      </li>
+      <li>If the user cancels the operation or no credential was selected:
+        <ol>
+          <li>Let |error| be a newly created {{"AbortError"}} {{DOMException}}.
+          </li>
+          <li>[=credential request coordinator/Reject request with=] |error|
+          and |promise|.
+          </li>
+          <li>Return.
+          </li>
+        </ol>
+      </li>
+      <li>If the platform returns a platform-specific error:
+        <ol>
+          <li>Let |error| be a {{DOMException}} determined as follows:
+            <dl class="switch">
+              <dt>
+                The user agent or platform does not permit the operation:
+              </dt>
+              <dd>
+                A newly created {{"NotAllowedError"}} {{DOMException}}.
+              </dd>
+              <dt>
+                The request data is malformed or invalid:
+              </dt>
+              <dd>
+                A newly created {{TypeError}}.
+              </dd>
+              <dt>
+                A credential request is already in progress:
+              </dt>
+              <dd>
+                A newly created {{"InvalidStateError"}} {{DOMException}}.
+              </dd>
+              <dt>
+                Otherwise:
+              </dt>
+              <dd>
+                A newly created {{"OperationError"}} {{DOMException}}.
+              </dd>
+            </dl>
+          </li>
+          <li>[=credential request coordinator/Reject request with=] |error|
+          and |promise|.
+          </li>
+          <li>Return.
+          </li>
+        </ol>
+      </li>
+      <li>If a [=digital credential=] was selected by the user:
+        <ol>
+          <li>Let |responseData| be a [=string=] [=digital
+          credential/presentation response=] or [=string=] [=digital
+          credential/issuance response=] returned by the [=holder=].
+            <aside class="note" title="Why the response is a string">
+              The response is a string because the user agent is responsible
+              for parsing it into a JavaScript object in the correct realm,
+              verifying it is valid JSON, and confirming the parsed value is an
+              object, as required by the {{DigitalCredential/data}} attribute.
+            </aside>
+          </li>
+          <li>Let |parsedDataOrError| be the result of [=parse a JSON string to
+          a JavaScript value=] passing |responseData|.
+          </li>
+          <li>If |parsedDataOrError| is an [=exception=]:
+            <ol>
+              <li>[=credential request coordinator/Reject request with=] |parsedDataOrError|
+              and |promise|.
+              </li>
+              <li>Return.
+              </li>
+            </ol>
+          </li>
+          <li>If |parsedDataOrError| is not an [=object=]:
+            <ol>
+              <li>Let |error| be a newly created {{TypeError}}.
+              </li>
+              <li>[=credential request coordinator/Reject request with=] |error|
+              and |promise|.
+              </li>
+              <li>Return.
+              </li>
+            </ol>
+          </li>
+          <li>Let |protocol:DigitalCredentialProtocol| be the
+          {{DigitalCredentialProtocol}} [=enumeration value=] that matches the
+          [=digital credential/protocol identifier=] used in the exchange.
+          </li>
+          <li>Let |credential| be a newly created {{DigitalCredential}}
+          instance with its {{DigitalCredential/data}} initialized to
+          |parsedDataOrError| and its {{DigitalCredential/protocol}}
+          initialized to |protocol|.
+          </li>
+          <li>[=Queue a global task=] on the [=DOM manipulation task source=]
+          given |document|'s [=relevant global object=] to perform the
+          following steps:
+            <ol>
+              <li>If the [=credential request coordinator=]'s [=credential
+              request coordinator/active promise=] is not |promise|, then
+              return.
+              </li>
+              <li>Let |abortSignal| be the [=credential request
+              coordinator=]'s [=credential request coordinator/abort
+              signal=].
+              </li>
+              <li>Let |abortAlgorithm| be the [=credential request
+              coordinator=]'s [=credential request coordinator/abort
+              algorithm=].
+              </li>
+              <li>If |abortSignal| is not `null` and |abortAlgorithm| is not
+              `null`, [=AbortSignal/Remove=] |abortAlgorithm| from
+              |abortSignal|.
+              </li>
+              <li>Set the [=credential request coordinator=]'s [=credential
+              request coordinator/abort signal=] to `null`.
+              </li>
+              <li>Set the [=credential request coordinator=]'s [=credential
+              request coordinator/abort algorithm=] to `null`.
+              </li>
+              <li>Set the [=credential request coordinator=] [=credential
+              request coordinator/interaction state=] to "[=credential request
+              coordinator/idle=]".
+              </li>
+              <li>[=Resolve=] |promise| with |credential|.
+              </li>
+              <li>Set the [=credential request coordinator=]'s [=credential
+              request coordinator/active promise=] to `null`.
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </li>
+    </ol><!--
     // MARK: The Digital Credentials API
     -->
     <h2>
@@ -1047,12 +1229,13 @@
     <p>
       The API allows [=digital credential/presentation request|requesting=] a
       [=digital credential=] from the user agent, which in turn presents a
-      [=credential chooser=] to the user, allowing them to select a [=digital
-      credential=] that can fulfill the request. This is done by the website
-      calling the `navigator.credentials.`{{CredentialsContainer/get()}}
-      method, which runs the [=request a `Credential`=] algorithm of
-      [[[credential-management]]]. That algorithm then calls back into this
-      specification's {{DigitalCredential}} interface's
+      [=digital credential chooser=] to the user, allowing them to select a
+      [=digital credential=] that can fulfill the request. This is done by the
+      website calling the
+      `navigator.credentials.`{{CredentialsContainer/get()}} method, which runs
+      the [=request a `Credential`=] algorithm of [[[credential-management]]].
+      That algorithm then calls back into this specification's
+      {{DigitalCredential}} interface's
       {{DigitalCredential/[[DiscoverFromExternalSource]](origin, options,
       sameOriginWithAncestors)}} internal method.
     </p>
@@ -1322,6 +1505,33 @@
       {{DigitalCredential}} in this specification.
     </p>
     <h4>
+      The request context struct
+    </h4>
+    <p>
+      A <dfn>request context</dfn> is a [=struct=] with the following
+      [=struct/items=]:
+    </p>
+    <dl>
+      <dt>
+        <dfn data-dfn-for="request context">requests</dfn>
+      </dt>
+      <dd>
+        A [=list=] of validated [=digital credential/credential requests=].
+      </dd>
+      <dt>
+        <dfn data-dfn-for="request context">top origin</dfn>
+      </dt>
+      <dd>
+        An [=origin=].
+      </dd>
+      <dt>
+        <dfn data-dfn-for="request context">document origin</dfn>
+      </dt>
+      <dd>
+        An [=origin=].
+      </dd>
+    </dl>
+    <h4>
       The {{DigitalCredentialPresentationProtocol}} enumeration
     </h4>
     <p>
@@ -1362,10 +1572,11 @@
       "DigitalCredential">[[\DiscoverFromExternalSource]](origin, options,
       sameOriginWithAncestors)</dfn> internal method, if the user agent doesn't
       support [=digital credential/presentation requests=] (e.g., the platform
-      cannot provide a [=credential chooser=]), call the default implementation
-      of {{Credential}}'s {{Credential/[[DiscoverFromExternalSource]](origin,
-      options, sameOriginWithAncestors)}} internal method with the same
-      arguments. Otherwise:
+      cannot provide a [=digital credential chooser=]), call the default
+      implementation of {{Credential}}'s
+      {{Credential/[[DiscoverFromExternalSource]](origin, options,
+      sameOriginWithAncestors)}} internal method with the same arguments.
+      Otherwise:
     </p>
     <ol class="algorithm">
       <li>Let |signal| be |options|'s {{CredentialRequestOptions/signal}}, if
@@ -1691,8 +1902,8 @@
         </p>
         <p>
           The Digital Credentials API offers the [=user agent=] the ability to
-          intermediate on behalf of the user (e.g. in the form of a
-          [=credential chooser=]) to contextualize requests and <a href=
+          intermediate on behalf of the user (e.g. in the form of a [=digital
+          credential chooser=]) to contextualize requests and <a href=
           "#permission-prior-to-wallet-selection">prevent immediate exposure to
           holder applications</a>. It also enforces certain minimum
           requirements on supported protocols, such as <a href=

--- a/index.html
+++ b/index.html
@@ -1070,7 +1070,7 @@
       </li>
       <li>[=In parallel=]:
         <ol>
-          <li>Present a [=digital credential chooser=] with |requestData| and
+          <li>Display a [=digital credential chooser=] with |requestData| and
           wait for one of the following outcomes:
             <ul>
               <li>The user selects a [=digital credential=] or [=holder=] that

--- a/index.html
+++ b/index.html
@@ -876,7 +876,7 @@
           </li>
         </ol>
       </li>
-      <li>[=credential request coordinator/Present the credential request=]
+      <li>[=credential request coordinator/Initiate the credential request=]
       with |document|, |validatedRequests|, |promise|, and |signal|.
       </li>
       <li>If |document| stops being [=Document/fully active=], [=credential
@@ -1048,13 +1048,13 @@
         </ol>
       </li>
     </ol><!--
-    // MARK: Present the credential request
+    // MARK: Initiate the credential request
     -->
     <h3>
-      Present the credential request
+      Initiate the credential request
     </h3>
     <p>
-      To <dfn data-dfn-for="credential request coordinator">present the
+      To <dfn data-dfn-for="credential request coordinator">initiate the
       credential request</dfn> given a [=Document=] |document|, a [=list=] of
       validated credential requests |validatedRequests|, a {{Promise}}
       |promise:Promise|, and an optional {{AbortSignal}} |signal|:

--- a/index.html
+++ b/index.html
@@ -1071,7 +1071,7 @@
         </ul>
         <aside class="issue" data-number="456"></aside>
       </li>
-      <li>If |signal| was passed and |signal| is [=AbortSignal/aborted=]:
+      <li>If |signal| is not null and |signal| is [=AbortSignal/aborted=]:
         <ol>
           <li>Return.
             <p class="note" title="Abort already handled">

--- a/index.html
+++ b/index.html
@@ -581,10 +581,10 @@
         <dfn>Digital credential chooser</dfn>
       </dt>
       <dd>
-        A platform-provided user interface that presents one or more
-        [=digital credential/credential requests=] to the user, allowing them
-        to select a [=digital credential=] or [=holder=] that can fulfill the
-        request, or cancel the operation.
+        A platform-provided user interface that presents one or more [=digital
+        credential/credential requests=] to the user, allowing them to select a
+        [=digital credential=] or [=holder=] that can fulfill the request, or
+        cancel the operation.
         <aside class="note" title="Relationship to credential chooser">
           The [=digital credential chooser=] may be invoked as part of a
           broader [=credential chooser=], or as a separate platform-provided
@@ -1060,168 +1060,178 @@
       |promise:Promise|, and an optional {{AbortSignal}} |signal|:
     </p>
     <ol class="algorithm">
-      <li>Let |topOrigin| be |document|'s [=top-level traversable=]'s
-      [=navigable/active document=]'s [=Document/origin=].
-      </li>
-      <li>Let |documentOrigin| be |document|'s [=Document/origin=].
+      <li>Let |topLevelOrigin| be |document|'s [=top-level traversable=]'s
+      [=navigable/active document=]'s [=relevant settings object=]'s
+      [=environment settings object/origin=].
       </li>
       <li>Let |requestData| be a new [=request context=] whose [=request
-      context/requests=] is |validatedRequests|, [=request context/top origin=]
-      is |topOrigin|, and [=request context/document origin=] is
-      |documentOrigin|.
+      context/requests=] is |validatedRequests| and [=request context/top-level
+      origin=] is |topLevelOrigin|.
       </li>
-      <li>Present a [=digital credential chooser=] with |requestData| and wait
-        for the user to do one of the following:
-        <ul>
-          <li>Select a [=digital credential=] or [=holder=] that can fulfill
-            the request.
-          </li>
-          <li>Cancel the operation.
-          </li>
-          <li>Encounter a platform-specific error.
-          </li>
-        </ul>
-        <aside class="issue" data-number="456"></aside>
-      </li>
-      <li>If |signal| is not null and |signal| is [=AbortSignal/aborted=]:
+      <li>[=In parallel=]:
         <ol>
-          <li>Return.
-            <p class="note" title="Abort already handled">
-              The algorithm [=AbortSignal/add|added=] to |signal| by the
-              [=credential request coordinator/prepare credential requests=]
-              steps handle tearing down the [=digital credential chooser=].
-            </p>
-          </li>
-        </ol>
-      </li>
-      <li>If the user cancels the operation or no credential was selected:
-        <ol>
-          <li>Let |error| be a newly created {{"NotAllowedError"}} {{DOMException}}.
-          </li>
-          <li>[=credential request coordinator/reject the credential request
-          with=] |error| and |promise|.
-          </li>
-          <li>Return.
-          </li>
-        </ol>
-      </li>
-      <li>If the platform returns a platform-specific error:
-        <ol>
-          <li>Let |error| be determined as follows:
-            <dl class="switch">
-              <dt>
-                The user agent or platform does not permit the operation:
-              </dt>
-              <dd>
-                A newly created {{"NotAllowedError"}} {{DOMException}}.
-              </dd>
-              <dt>
-                The request data is malformed or invalid:
-              </dt>
-              <dd>
-                A newly created {{TypeError}}.
-              </dd>
-              <dt>
-                A credential request is already in progress:
-              </dt>
-              <dd>
-                A newly created {{"InvalidStateError"}} {{DOMException}}.
-              </dd>
-              <dt>
-                Otherwise:
-              </dt>
-              <dd>
-                A newly created {{"OperationError"}} {{DOMException}}.
-              </dd>
-            </dl>
-          </li>
-          <li>[=credential request coordinator/reject the credential request
-          with=] |error| and |promise|.
-          </li>
-          <li>Return.
-          </li>
-        </ol>
-      </li>
-      <li>If a [=digital credential=] was selected by the user:
-        <ol>
-          <li>Let |selectedRequest| be the item in |validatedRequests| that was
-          used to invoke the [=holder=] for this exchange.
-          </li>
-          <li>Let |responseData| be a [=string=] [=digital
-          credential/presentation response=] or [=string=] [=digital
-          credential/issuance response=] returned by the [=holder=].
-            <aside class="note" title="Why the response is a string">
-              The response is a string because the user agent is responsible
-              for parsing it into a JavaScript object in the correct realm,
-              verifying it is valid JSON, and confirming the parsed value is an
-              object, as required by the {{DigitalCredential/data}} attribute.
-            </aside>
-          </li>
-          <li>Let |parsedDataOrError| be the result of [=parse a JSON string to
-          a JavaScript value=] passing |responseData|.
-          </li>
-          <li>If |parsedDataOrError| is an [=exception=]:
-            <ol>
-              <li>[=credential request coordinator/reject the credential
-              request with=] |parsedDataOrError| and |promise|.
+          <li>Present a [=digital credential chooser=] with |requestData| and
+          wait for one of the following outcomes:
+            <ul>
+              <li>The user selects a [=digital credential=] or [=holder=] that
+              can fulfill the request.
               </li>
+              <li>The user cancels the operation.
+              </li>
+              <li>The platform encounters an error.
+              </li>
+            </ul>
+            <aside class="issue" data-number="456"></aside>
+          </li>
+          <li>If |signal| is not null and |signal| is [=AbortSignal/aborted=]:
+            <ol>
               <li>Return.
+                <p class="note" title="Abort already handled">
+                  The abort algorithm [=AbortSignal/add|added=] to |signal| by
+                  the [=credential request coordinator/prepare credential
+                  requests=] steps handles tearing down the [=digital
+                  credential chooser=].
+                </p>
               </li>
             </ol>
           </li>
-          <li>If |parsedDataOrError| is not an [=object=]:
+          <li>If the user cancels the operation or no credential was selected:
             <ol>
-              <li>Let |error| be a newly created {{TypeError}}.
+              <li>Let |error| be a newly created {{"NotAllowedError"}}
+              {{DOMException}}.
               </li>
-              <li>[=credential request coordinator/reject the credential
+              <li>[=credential request coordinator/Reject the credential
               request with=] |error| and |promise|.
               </li>
               <li>Return.
               </li>
             </ol>
           </li>
-          <li>Let |protocol:DigitalCredentialProtocol| be the [=enumeration
-          value=] of |selectedRequest|'s [=digital credential/protocol
-          identifier=].
-          </li>
-          <li>Let |credential| be a newly created {{DigitalCredential}}
-          instance with its {{DigitalCredential/data}} initialized to
-          |parsedDataOrError| and its {{DigitalCredential/protocol}}
-          initialized to |protocol|.
-          </li>
-          <li>[=Queue a global task=] on the [=DOM manipulation task source=]
-          given |document|'s [=relevant global object=] to perform the
-          following steps:
+          <li>If the platform returns a platform-specific error:
             <ol>
-              <li>If the [=credential request coordinator=]'s [=credential
-              request coordinator/active promise=] is not |promise|, then
-              return.
+              <li>Let |error| be determined as follows:
+                <dl class="switch">
+                  <dt>
+                    The user agent or platform does not permit the operation:
+                  </dt>
+                  <dd>
+                    A newly created {{"NotAllowedError"}} {{DOMException}}.
+                  </dd>
+                  <dt>
+                    The request data is malformed or invalid:
+                  </dt>
+                  <dd>
+                    A newly created {{TypeError}}.
+                  </dd>
+                  <dt>
+                    A credential request is already in progress:
+                  </dt>
+                  <dd>
+                    A newly created {{"InvalidStateError"}} {{DOMException}}.
+                  </dd>
+                  <dt>
+                    Otherwise:
+                  </dt>
+                  <dd>
+                    A newly created {{"OperationError"}} {{DOMException}}.
+                  </dd>
+                </dl>
               </li>
-              <li>Let |abortSignal| be the [=credential request coordinator=]'s
-              [=credential request coordinator/abort signal=].
+              <li>[=credential request coordinator/Reject the credential
+              request with=] |error| and |promise|.
               </li>
-              <li>Let |abortAlgorithm| be the [=credential request
-              coordinator=]'s [=credential request coordinator/abort
-              algorithm=].
+              <li>Return.
               </li>
-              <li>If |abortSignal| is not `null` and |abortAlgorithm| is not
-              `null`, [=AbortSignal/Remove=] |abortAlgorithm| from
-              |abortSignal|.
+            </ol>
+          </li>
+          <li>If a [=digital credential=] was selected by the user:
+            <ol>
+              <li>Let |protocol| be the [=digital credential/protocol
+              identifier=] returned by the [=digital credential chooser=] for
+              this exchange.
+                <p class="note" title="Protocol is determined by the platform">
+                  The [=digital credential chooser=] or underlying platform
+                  determines which item in |validatedRequests| to forward to a
+                  [=holder=] and returns the [=digital credential/protocol
+                  identifier=] for that exchange. The user agent does not
+                  necessarily know which specific item was selected.
+                </p>
               </li>
-              <li>Set the [=credential request coordinator=]'s [=credential
-              request coordinator/abort signal=] to `null`.
+              <li>Let |responseData| be a [=string=] [=digital
+              credential/presentation response=] or [=string=] [=digital
+              credential/issuance response=] returned by the [=holder=].
+                <aside class="note" title="Why the response is a string">
+                  The response is a string because the user agent is
+                  responsible for parsing it into a JavaScript object in the
+                  correct realm, verifying it is valid JSON, and confirming the
+                  parsed value is an object, as required by the
+                  {{DigitalCredential/data}} attribute.
+                </aside>
               </li>
-              <li>Set the [=credential request coordinator=]'s [=credential
-              request coordinator/abort algorithm=] to `null`.
-              </li>
-              <li>Set the [=credential request coordinator=] [=credential
-              request coordinator/interaction state=] to "[=credential request
-              coordinator/idle=]".
-              </li>
-              <li>[=Resolve=] |promise| with |credential|.
-              </li>
-              <li>Set the [=credential request coordinator=]'s [=credential
-              request coordinator/active promise=] to `null`.
+              <li>[=Queue a global task=] on the [=DOM manipulation task
+              source=] given |document|'s [=relevant global object=] to perform
+              the following steps:
+                <ol>
+                  <li>If the [=credential request coordinator=]'s [=credential
+                  request coordinator/active promise=] is not |promise|, then
+                  return.
+                  </li>
+                  <li>Let |parsedResponseDataOrError| be the result of [=parse
+                  a JSON string to a JavaScript value=] given |responseData|.
+                  </li>
+                  <li>Let |abortSignal| be the [=credential request
+                  coordinator=]'s [=credential request coordinator/abort
+                  signal=].
+                  </li>
+                  <li>Let |abortAlgorithm| be the [=credential request
+                  coordinator=]'s [=credential request coordinator/abort
+                  algorithm=].
+                  </li>
+                  <li>If |abortSignal| is not `null` and |abortAlgorithm| is
+                  not `null`, [=AbortSignal/Remove=] |abortAlgorithm| from
+                  |abortSignal|.
+                  </li>
+                  <li>Set the [=credential request coordinator=]'s [=credential
+                  request coordinator/abort signal=] to `null`.
+                  </li>
+                  <li>Set the [=credential request coordinator=]'s [=credential
+                  request coordinator/abort algorithm=] to `null`.
+                  </li>
+                  <li>If |parsedResponseDataOrError| is an [=exception=]:
+                    <ol>
+                      <li>[=Reject=] |promise| with
+                      |parsedResponseDataOrError|.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>Otherwise, if |parsedResponseDataOrError| is not an
+                  [=object=]:
+                    <ol>
+                      <li>[=Reject=] |promise| with a newly created
+                      {{TypeError}}.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>Otherwise:
+                    <ol>
+                      <li>Let |credential| be a newly created
+                      {{DigitalCredential}} instance with its
+                      {{DigitalCredential/data}} initialized to
+                      |parsedResponseDataOrError| and its
+                      {{DigitalCredential/protocol}} initialized to |protocol|.
+                      </li>
+                      <li>[=Resolve=] |promise| with |credential|.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>Set the [=credential request coordinator=]'s [=credential
+                  request coordinator/active promise=] to `null`.
+                  </li>
+                  <li>Set the [=credential request coordinator=] [=credential
+                  request coordinator/interaction state=] to "[=credential
+                  request coordinator/idle=]".
+                  </li>
+                </ol>
               </li>
             </ol>
           </li>
@@ -1536,26 +1546,11 @@
         A [=list=] of validated [=digital credential/credential requests=].
       </dd>
       <dt>
-        <dfn data-dfn-for="request context">top origin</dfn>
+        <dfn data-dfn-for="request context">top-level origin</dfn>
       </dt>
       <dd>
-        An [=origin=].
-      </dd>
-      <dt>
-        <dfn data-dfn-for="request context">document origin</dfn>
-      </dt>
-      <dd>
-        An [=origin=].
-        <p class="note" title=
-        "Why both origins are included in the request context">
-          The [=request context/document origin=] can differ from the [=request
-          context/top origin=] when the API is called from a cross-origin
-          [^iframe^] (e.g., an embedded verification service). Including both
-          origins allows the [=digital credential chooser=] and [=holder=] to
-          make informed trust decisions about which party is actually
-          requesting the credential, not just which top-level site is hosting
-          the request.
-        </p>
+        An [=environment settings object=]'s [=environment settings
+        object/origin=].
       </dd>
     </dl>
     <h4>

--- a/index.html
+++ b/index.html
@@ -1095,7 +1095,7 @@
       </li>
       <li>If the platform returns a platform-specific error:
         <ol>
-          <li>Let |error| be a {{DOMException}} determined as follows:
+          <li>Let |error| be determined as follows:
             <dl class="switch">
               <dt>
                 The user agent or platform does not permit the operation:


### PR DESCRIPTION
Defines the "present the credential request" algorithm — the core user-facing part of the Digital Credentials flow that happens after validation passes.

## What the algorithm does

Once the credential requests have been validated (by the "prepare" algorithm), this algorithm:

1. **Constructs a request context** — bundles the validated requests with the top-level and document origins, so the platform/chooser knows who is asking and from where.
2. **Presents a digital credential chooser** — a UA-provided UI that shows the user available credentials from registered holders. The user can select a credential, cancel, or the operation can be aborted via an `AbortSignal`.
3. **Handles abort** — if the signal fires, the algorithm returns (the abort callback was already wired up by the "prepare" steps).
4. **Handles cancellation** — rejects with `AbortError`.
5. **Maps platform errors** — translates platform-specific failures to web-facing errors: `NotAllowedError` (permission denied), `TypeError` (malformed request data), `InvalidStateError` (concurrent request), or `OperationError` (catch-all).
6. **Processes the response** — parses the holder's response as JSON, validates it's an object, constructs a `DigitalCredential` instance with `data` and `protocol`, resolves the promise, and cleans up coordinator state.

## New terms introduced

- **Digital credential chooser** — the UA-provided UI for credential selection
- **Request context** — a struct carrying `requests`, `top origin`, and `document origin` into the chooser

Closes #419

The following tasks have been completed:

- [x] Modified Web platform tests (https://github.com/web-platform-tests/wpt/pull/59087)

Implementation commitment:

- [x] [WebKit](https://github.com/WebKit/WebKit/pull/56489)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [x] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/419.html" title="Last updated on Apr 29, 2026, 10:38 PM UTC (001a6df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/419/4c1c0df...001a6df.html" title="Last updated on Apr 29, 2026, 10:38 PM UTC (001a6df)">Diff</a>