### PR TITLE
Editorial: return promises instead of throwing exceptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1003,24 +1003,27 @@
       <li>Let |document| be |global|'s [=associated `Document`=].
       </li>
       <li>If |document| is not a [=Document/fully active descendant of a
-      top-level traversable with user attention=], [=exception/throw=]
-      {{"NotAllowedError"}} {{DOMException}}.
+      top-level traversable with user attention=], return [=a promise rejected
+      with=] a {{"NotAllowedError"}} {{DOMException}}.
       </li>
-      <li>If |window| does not have [=transient activation=],
-      [=exception/throw=] {{"NotAllowedError"}} {{DOMException}}.
+      <li>If |window| does not have [=transient activation=], return [=a
+      promise rejected with=] a {{"NotAllowedError"}} {{DOMException}}.
       </li>
       <li>[=Consume user activation=] of |window|.
       </li>
       <li>Let |requests| be |options|'s {{CredentialRequestOptions/digital}}'s
       {{DigitalCredentialRequestOptions/requests}} member.
       </li>
-      <li>If |requests| is empty, [=exception/throw=] a {{TypeError}}.
+      <li>If |requests| is empty, return [=a promise rejected with=] a
+      {{TypeError}}.
       </li>
       <li>[=List/For each=] |request| of |requests|:
         <ol>
           <li>[=serialize a JavaScript value to a JSON string|Serialize=]
-          |request| to a JSON string. [=exception/throw|Re-throw=] any
-          [=exception=].
+          |request| to a JSON string.
+          </li>
+          <li>If serialization results in an [=exception=], return [=a promise
+          rejected with=] that [=exception=].
           </li>
         </ol>
       </li>
@@ -1064,24 +1067,27 @@
       <li>Let |document| be |global|'s [=associated `Document`=].
       </li>
       <li>If |document| is not a [=Document/fully active descendant of a
-      top-level traversable with user attention=], [=exception/throw=]
-      {{"NotAllowedError"}} {{DOMException}}.
+      top-level traversable with user attention=], return [=a promise rejected
+      with=] a {{"NotAllowedError"}} {{DOMException}}.
       </li>
-      <li>If |window| does not have [=transient activation=],
-      [=exception/throw=] {{"NotAllowedError"}} {{DOMException}}.
+      <li>If |window| does not have [=transient activation=], return [=a
+      promise rejected with=] a {{"NotAllowedError"}} {{DOMException}}.
       </li>
       <li>[=Consume user activation=] of |window|.
       </li>
       <li>Let |requests| be |options|'s {{CredentialCreationOptions/digital}}'s
       {{DigitalCredentialCreationOptions/requests}} member.
       </li>
-      <li>If |requests| is empty, [=exception/throw=] a {{TypeError}}.
+      <li>If |requests| is empty, return [=a promise rejected with=] a
+      {{TypeError}}.
       </li>
       <li>[=List/For each=] |request| of |requests|:
         <ol>
           <li>[=serialize a JavaScript value to a JSON string|Serialize=]
-          |request| to a JSON string. [=exception/throw|Re-throw=] any
-          [=exception=].
+          |request| to a JSON string.
+          </li>
+          <li>If serialization results in an [=exception=], return [=a promise
+          rejected with=] that [=exception=].
           </li>
         </ol>
       </li>


### PR DESCRIPTION
Updates the error handling steps in the digital credential request and creation algorithms to return rejected promises instead of throwing exceptions. This allows Cred Man to handle the promise unwrapping, resulting in the appropriate promise rejections (and avoids mixing throwing exceptions and with rejecting promises). This also matches what browsers already do.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/431.html" title="Last updated on Jan 13, 2026, 12:47 AM UTC (927ef54)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/431/97eb9f8...927ef54.html" title="Last updated on Jan 13, 2026, 12:47 AM UTC (927ef54)">Diff</a>