### PR TITLE
Editorial: fix double-code on openid4vp-* dfns

### DIFF
--- a/index.html
+++ b/index.html
@@ -599,7 +599,7 @@
           </td>
           <td>
             <dfn data-dfn-for=
-            "DigitalCredentialPresentationProtocol">`openid4vp-v1-unsigned`</dfn>
+            "DigitalCredentialPresentationProtocol">openid4vp-v1-unsigned</dfn>
           </td>
           <td>
             [[OPENID4VP]] <a data-cite=
@@ -615,7 +615,7 @@
           </td>
           <td>
             <dfn data-dfn-for=
-            "DigitalCredentialPresentationProtocol">`openid4vp-v1-signed`</dfn>
+            "DigitalCredentialPresentationProtocol">openid4vp-v1-signed</dfn>
           </td>
           <td>
             [[OPENID4VP]] <a data-cite="OPENID4VP#name-signed-request">Appendix
@@ -631,7 +631,7 @@
           </td>
           <td>
             <dfn data-dfn-for=
-            "DigitalCredentialPresentationProtocol">`openid4vp-v1-multisigned`</dfn>
+            "DigitalCredentialPresentationProtocol">openid4vp-v1-multisigned</dfn>
           </td>
           <td>
             [[OPENID4VP]] <a data-cite=
@@ -647,7 +647,7 @@
           </td>
           <td>
             <dfn data-dfn-for=
-            "DigitalCredentialPresentationProtocol">`org-iso-mdoc`</dfn>
+            "DigitalCredentialPresentationProtocol">org-iso-mdoc</dfn>
           </td>
           <td>
             [[ISO18013-7]] Annex C


### PR DESCRIPTION
Unnecessary use of "\`" in the dfns. ReSpec automatically adds `<code>` to IDL definitions (which otherwise can result in nested `<code><code>`).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/449.html" title="Last updated on Jan 28, 2026, 2:28 AM UTC (bb0a37b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/449/a54aa7c...bb0a37b.html" title="Last updated on Jan 28, 2026, 2:28 AM UTC (bb0a37b)">Diff</a>