### PR TITLE
Add "Abort the credential request" algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -800,8 +800,12 @@
           coordinator/interaction state=] to "[=credential request
           coordinator/aborting=]".
           </li>
-          <li>Dismiss the [=credential chooser=] and await confirmation of
-          dismissal.
+          <li>Dismiss the [=credential chooser=].
+            <p class="note">
+              Dismissal can fail (e.g., if the [=credential chooser=] was
+              destroyed due to memory pressure), but the [=coordinator=]
+              proceeds to complete the credential request regardless.
+            </p>
           </li>
         </ol>
       </li>


### PR DESCRIPTION
Closes #435

This algorithm is used to handle aborting the credential request when:

* The associated AbortSignal is aborted.
* The document becomes non-fully active.
* The iframe handling the request is destroyed.

The following tasks have been completed:

- [x] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/57556)

Implementation commitment:

- [X] WebKit (link to issue)
- [x] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/462.html" title="Last updated on Feb 26, 2026, 6:14 PM UTC (3f118c5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/462/43aeeda...3f118c5.html" title="Last updated on Feb 26, 2026, 6:14 PM UTC (3f118c5)">Diff</a>