### PR TITLE
Add slots for abort management

### DIFF
--- a/index.html
+++ b/index.html
@@ -799,6 +799,24 @@
           <li>If the [=credential request coordinator=]'s [=credential request
           coordinator/active promise=] is not |promise|, then return.
           </li>
+          <li>Let |signal| be the [=credential request coordinator=]'s
+          [=credential request coordinator/abort signal=].
+          </li>
+          <li>Let |abortAlgorithm| be the [=credential request coordinator=]'s
+          [=credential request coordinator/abort algorithm=].
+          </li>
+          <li>If |signal| is not `null` and |abortAlgorithm| is not `null`:
+            <ol>
+              <li>[=AbortSignal/Remove=] |abortAlgorithm| from |signal|.
+              </li>
+            </ol>
+          </li>
+          <li>Set the [=credential request coordinator=]'s [=credential request
+          coordinator/abort signal=] to `null`.
+          </li>
+          <li>Set the [=credential request coordinator=]'s [=credential request
+          coordinator/abort algorithm=] to `null`.
+          </li>
           <li>[=Reject=] |promise| with |error|.
           </li>
           <li>Set the [=credential request coordinator=]'s [=credential request


### PR DESCRIPTION
Add two new slots maintained by the credential request coordinator: an abort signal and an abort algorithm. This is to manage removal of the algorithm from the appropriate signal.


The following tasks have been completed:

- [ ] <del>Modified Web platform tests</del> - not testable.

Implementation commitment:

- [X] [WebKit](https://github.com/WebKit/WebKit/pull/57819)
- [ ] Chromium
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/463.html" title="Last updated on Feb 18, 2026, 11:48 PM UTC (def35ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/463/c35a8a8...def35ee.html" title="Last updated on Feb 18, 2026, 11:48 PM UTC (def35ee)">Diff</a>