### PR TITLE
Editorial: fix typo DigitalCredentialsProtocol -> DigitalCredentialProtocol

### DIFF
--- a/index.html
+++ b/index.html
@@ -997,12 +997,12 @@
       non-overridable behavior of the API.
     </p>
     <pre class="idl">
-    typedef DigitalCredentialPresentationProtocol DigitalCredentialsProtocol;
+    typedef DigitalCredentialPresentationProtocol DigitalCredentialProtocol;
 
     [Exposed=Window, SecureContext]
     interface DigitalCredential : Credential {
       [Default] object toJSON();
-      readonly attribute DigitalCredentialsProtocol protocol;
+      readonly attribute DigitalCredentialProtocol protocol;
       [SameObject] readonly attribute object data;
       static boolean userAgentAllowsProtocol(DOMString protocol);
     };
@@ -1059,7 +1059,7 @@
     </p>
     <ol class="algorithm">
       <li>If |protocol| is not an [=enumeration value=] of
-      {{DigitalCredentialsProtocol}}, return `false`.
+      {{DigitalCredentialProtocol}}, return `false`.
       </li>
       <li>Return `true` if the user agent allows |protocol|, otherwise return
       `false`.


### PR DESCRIPTION
Should be singular.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/464.html" title="Last updated on Feb 4, 2026, 5:32 AM UTC (62f5b77)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/464/7946da0...62f5b77.html" title="Last updated on Feb 4, 2026, 5:32 AM UTC (62f5b77)">Diff</a>