### PR TITLE
All requests must go to client platform for cross-device

### DIFF
--- a/index.html
+++ b/index.html
@@ -574,12 +574,12 @@
       supported presentation and issuance protocols=].
     </p>
     <p>
-      If a [=user agent=] does not support any {{DigitalCredentialGetRequest}}
-      or {{DigitalCredentialCreateRequest}} objects within the
-      {{DigitalCredentialRequestOptions/requests}} member, it MUST pass
-      the entire DigitalCredentialRequestOptions value to the
-      underlying client platform, or appropriate internal mechanism,
-      for cross-device handling.
+      [=User agents=] MUST pass the entire DigitalCredentialRequestOptions
+      value to the underlying client platform, or appropriate internal mechanism,
+      for cross-device handling, regardless of whether the user agent itself
+      supports the protocol(s) specified in the request options. This allows
+      the platform to determine whether the request can be handled on a different
+      device, even if the current user agent does not support the protocol(s).
     </p>
     <aside class="note" title="Checking which protocols a user agent allows">
       <p>

--- a/index.html
+++ b/index.html
@@ -574,8 +574,8 @@
       supported presentation and issuance protocols=].
     </p>
     <p>
-      [=User agents=] MUST pass the entire DigitalCredentialRequestOptions
-      value to the underlying client platform, or appropriate internal mechanism,
+      [=User agents=] MUST pass the entire `DigitalCredentialRequestOptions`
+      value to the underlying client platform, or appropriate internal mechanism
       for cross-device handling, regardless of whether the user agent itself
       supports the protocol(s) specified in the request options. This allows
       the platform to determine whether the request can be handled on a different

--- a/index.html
+++ b/index.html
@@ -567,11 +567,19 @@
       defined by this specification.
     </p>
     <p>
-      A [=user agent=] MUST implement at least one of the [=digital
+      A [=user agent=] MUST directly implement at least one of the [=digital
       credential/presentation protocols=] &mdash; and it is RECOMMENDED
       that they implement <em>all</em> [=digital credential/presentation
       and issuance protocols=] &mdash; listed in the [=table of
       supported presentation and issuance protocols=].
+    </p>
+    <p>
+      If a [=user agent=] does not support any {{DigitalCredentialGetRequest}}
+      or {{DigitalCredentialCreateRequest}} objects within the
+      {{DigitalCredentialRequestOptions/requests}} member, it MUST pass
+      the entire DigitalCredentialRequestOptions value to the
+      underlying client platform, or appropriate internal mechanism,
+      for cross-device handling.
     </p>
     <aside class="note" title="Checking which protocols a user agent allows">
       <p>

--- a/index.html
+++ b/index.html
@@ -567,7 +567,7 @@
       defined by this specification.
     </p>
     <p>
-      A [=user agent=] MUST directly implement at least one of the [=digital
+      A [=user agent=] MUST implement at least one of the [=digital
       credential/presentation protocols=] &mdash; and it is RECOMMENDED
       that they implement <em>all</em> [=digital credential/presentation
       and issuance protocols=] &mdash; listed in the [=table of


### PR DESCRIPTION
Updates PR #454 to mandate sending requests to the client platform to support cross-device

The following tasks have been completed:

- [ ] Modified Web platform tests (link)

[protocol-filtering-openid4vp.https.html](https://github.com/web-platform-tests/wpt/blob/master/digital-credentials/protocol-filtering-openid4vp.https.html) and [protocol-filtering-mdoc.https.html](https://github.com/web-platform-tests/wpt/blob/master/digital-credentials/protocol-filtering-mdoc.https.html) currently assert that a request whose protocol the user agent does not allow is filtered out, and that the call rejects with a `TypeError` when none survive. Those tests would need updating to match this requirement.

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

WebKit and Chromium both drop requests with unsupported protocols before dispatching to the platform, so this would be a behavior change in both.

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/474.html" title="Last updated on Aug 19, 2026, 3:08 AM UTC (af949d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/474/836e32e...af949d4.html" title="Last updated on Aug 19, 2026, 3:08 AM UTC (af949d4)">Diff</a>