### PR TITLE
Address order of serialization vs protocol filtering (issue #475)

### DIFF
--- a/index.html
+++ b/index.html
@@ -892,7 +892,7 @@
           <li>If the [=user agent=] does not allow |protocol|,
           [=iteration/continue=].
           </li>
-          <li>Let |data:object| be |request|'s {{DigitalCredentialGetRequest/data}},
+          <li>Let |data| be |request|'s {{DigitalCredentialGetRequest/data}},
           if |request| is a {{DigitalCredentialGetRequest}}, or |request|'s
           {{DigitalCredentialCreateRequest/data}}, if |request| is a
           {{DigitalCredentialCreateRequest}}.


### PR DESCRIPTION
Closes #475

The following tasks have been completed:

- [x] Modified Web platform tests https://github.com/web-platform-tests/wpt/pull/58581 

Implementation commitment:

- [X] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=310257)
- [X] [Chromium](https://crbug.com/493952670)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/477.html" title="Last updated on Mar 26, 2026, 8:47 AM UTC (c463b2a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/477/dbea581...c463b2a.html" title="Last updated on Mar 26, 2026, 8:47 AM UTC (c463b2a)">Diff</a>