### PR TITLE
Editorial: rename "Request data" to "Presentation request data"

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,7 +269,7 @@
                 digital: {
                   requests: [{
                     protocol,
-                    data: { /* request data */ }
+                    data: { /* presentation request data */ }
                   }]
                 }
               });

--- a/index.html
+++ b/index.html
@@ -429,8 +429,8 @@
       capabilities to [=digital credential/presentation|present=] or [=digital
       credential/issuance|issue=] them to the [=user agent=], is out of scope.
       The only exception is the transmission of [=digital credential/issuance
-      request data=] and [=digital credential/request data|credential request
-      data=] to and from such software.
+      request data=] and [=digital credential/presentation request data=] to
+      and from such software.
       </li>
     </ul><!--
     // MARK: Model
@@ -462,11 +462,11 @@
       </dt>
       <dd>
         A presentation request is a request for a [=digital credential=]
-        composed of [=digital credential/request data=] and a [=digital
-        credential/presentation protocol=].
+        composed of [=digital credential/presentation request data=] and a
+        [=digital credential/presentation protocol=].
       </dd>
       <dt>
-        <dfn data-dfn-for="digital credential">Request data</dfn>
+        <dfn data-dfn-for="digital credential">Presentation request data</dfn>
       </dt>
       <dd>
         A format that [=verifier=] software or a [=user agent=] uses, via an
@@ -892,22 +892,25 @@
           <li>If the [=user agent=] does not allow |protocol|,
           [=iteration/continue=].
           </li>
-          <li>Validate |request|'s [=digital credential/request data=]
-          according to |request|'s [=digital credential/presentation protocol=]
-          or [=digital credential/issuance protocol=] or other criteria.
-          Validation requirements are protocol-specific and are outside the
-          scope of this specification:
+          <li>Validate |request|'s [=digital credential/presentation request
+          data=] or [=digital credential/issuance request data=] according to
+          |request|'s [=digital credential/presentation protocol=] or [=digital
+          credential/issuance protocol=] or other criteria. Validation
+          requirements are protocol-specific and are outside the scope of this
+          specification:
             <aside class="note" title="Validation details outside scope">
               <p>
                 Validation includes verifying |request|'s [=digital
-                credential/request data=] conforms to the requirements of the
-                specified [=digital credential/presentation protocol=] or
-                [=digital credential/issuance protocol=]. Please refer to the
-                specification of the specific [=digital credential/presentation
-                protocol=] or [=digital credential/issuance protocol=] for
-                details, including potential reasons for validation failure,
-                and any security and privacy considerations that need to be
-                considered by implementers during validation.
+                credential/presentation request data=] or [=digital
+                credential/issuance request data=] conforms to the requirements
+                of the specified [=digital credential/presentation protocol=]
+                or [=digital credential/issuance protocol=]. Please refer to
+                the specification of the specific [=digital
+                credential/presentation protocol=] or [=digital
+                credential/issuance protocol=] for details, including potential
+                reasons for validation failure, and any security and privacy
+                considerations that need to be considered by implementers
+                during validation.
               </p>
             </aside>
             <aside class="issue" data-number="472"></aside>
@@ -1094,8 +1097,8 @@
     <p>
       The <dfn data-dfn-for="DigitalCredentialRequestOptions">requests</dfn>
       specify an [=digital credential/presentation protocol=] and [=digital
-      credential/request data=], which the user agent MAY match against a
-      holder's software, such as a digital wallet.
+      credential/presentation request data=], which the user agent MAY match
+      against a holder's software, such as a digital wallet.
     </p><!--
     // MARK: DigitalCredentialGetRequest
     -->
@@ -1105,9 +1108,9 @@
     <p>
       The {{DigitalCredentialGetRequest}} dictionary represents a [=digital
       credential/presentation request=]. It is used to specify an [=digital
-      credential/presentation protocol=] and some [=digital credential/request
-      data=], which the user agent MAY match against software used by a holder,
-      such as a digital wallet.
+      credential/presentation protocol=] and some [=digital
+      credential/presentation request data=], which the user agent MAY match
+      against software used by a holder, such as a digital wallet.
     </p>
     <pre class="idl">
       dictionary DigitalCredentialGetRequest {
@@ -1132,8 +1135,8 @@
     </h4>
     <p>
       The <dfn data-dfn-for="DigitalCredentialGetRequest">data</dfn> member is
-      the [=digital credential/request data=] to be handled by the holder's
-      credential provider, such as a digital identity wallet.
+      the [=digital credential/presentation request data=] to be handled by the
+      holder's credential provider, such as a digital identity wallet.
     </p><!--
     // MARK: CredentialCreationOptions
     -->
@@ -1168,7 +1171,7 @@
     <p>
       The <dfn data-dfn-for="DigitalCredentialCreationOptions">requests</dfn>
       specify an [=digital credential/issuance protocol=] and [=digital
-      credential/request data=], which the user agent MAY forward to a
+      credential/issuance request data=], which the user agent MAY forward to a
       [=holder=].
     </p><!--
     // MARK: DigitalCredentialCreateRequest
@@ -1179,9 +1182,9 @@
     <p>
       The {{DigitalCredentialCreateRequest}} dictionary represents an [=digital
       credential/issuance request=]. It is used to specify an [=digital
-      credential/issuance protocol=] and some [=digital credential/request
-      data=], to communicate the issuance request between the issuer and the
-      holder.
+      credential/issuance protocol=] and some [=digital credential/issuance
+      request data=], to communicate the issuance request between the issuer
+      and the holder.
     </p>
     <pre class="idl">
     dictionary DigitalCredentialCreateRequest {
@@ -1206,8 +1209,8 @@
     </h4>
     <p>
       The <dfn data-dfn-for="DigitalCredentialCreateRequest">data</dfn> member
-      is the [=digital credential/request data=] to be handled by the holder's
-      credential provider, such as a digital identity wallet.
+      is the [=digital credential/issuance request data=] to be handled by the
+      holder's credential provider, such as a digital identity wallet.
     </p><!--
     // MARK: DigitalCredential interface
     -->


### PR DESCRIPTION
Closes #482. Renames the "Request data" term to "Presentation request data" for symmetry with "Issuance request data", and fixes all references to use the precise term in their respective contexts.

cc @c2bo


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/483.html" title="Last updated on Apr 10, 2026, 6:05 AM UTC (df1ac7c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/483/c381c8f...df1ac7c.html" title="Last updated on Apr 10, 2026, 6:05 AM UTC (df1ac7c)">Diff</a>