### PR TITLE
editorial: explain how userAgentAllowsProtocol() future-proofs the API

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@
         (detectable via the `typeof` check shown above), protocol identifiers
         are added to {{DigitalCredentialProtocol}} progressively as
         [=user agents=] adopt support for them, so calling this method with an
-        unknown protocol identifier safely returns `false` without throwing.
+        unknown protocol identifier safely returns `false` without [exception/throw|throwing=] an [=exception=].
         Note that calling this method on a browser where {{DigitalCredential}}
         is not defined will throw a {{ReferenceError}}, so the
         `typeof DigitalCredential !== "undefined"` guard shown above is still

--- a/index.html
+++ b/index.html
@@ -210,12 +210,15 @@
         be used to check if the user agent allows a specific protocol for
         digital credential issuance or presentation. This is useful for
         checking which protocols are allowed by the user's browsers prior to
-        making an API call. Because protocol identifiers are added to
-        {{DigitalCredentialProtocol}} progressively as [=user agents=] adopt
-        support for them, calling this method on an older browser with a newer
-        protocol identifier safely returns `false`. This makes it suitable for
-        feature detection without needing to guard against exceptions on legacy
-        browsers.
+        making an API call. On browsers that implement {{DigitalCredential}}
+        (detectable via the `typeof` check shown above), protocol identifiers
+        are added to {{DigitalCredentialProtocol}} progressively as
+        [=user agents=] adopt support for them, so calling this method with an
+        unknown protocol identifier safely returns `false` without throwing.
+        Note that calling this method on a browser where {{DigitalCredential}}
+        is not defined will throw a {{ReferenceError}}, so the
+        `typeof DigitalCredential !== "undefined"` guard shown above is still
+        required before using this method.
       </p>
       <pre class="example js" title=
       "Using the userAgentAllowsProtocol() static method">

--- a/index.html
+++ b/index.html
@@ -210,7 +210,12 @@
         be used to check if the user agent allows a specific protocol for
         digital credential issuance or presentation. This is useful for
         checking which protocols are allowed by the user's browsers prior to
-        making an API call.
+        making an API call. Because protocol identifiers are added to
+        {{DigitalCredentialProtocol}} progressively as [=user agents=] adopt
+        support for them, calling this method on an older browser with a newer
+        protocol identifier safely returns `false`. This makes it suitable for
+        feature detection without needing to guard against exceptions on legacy
+        browsers.
       </p>
       <pre class="example js" title=
       "Using the userAgentAllowsProtocol() static method">
@@ -237,6 +242,26 @@
           // At least one protocol is supported. Proceed with issuance.
         } else {
           // No protocols are supported. Fall back to a different issuance method.
+        }
+      </pre>
+      <p>
+        Because protocol identifiers are added to {{DigitalCredentialProtocol}}
+        progressively, one can use this method to prefer a newer protocol while
+        gracefully falling back to an older one on legacy browsers:
+      </p>
+      <pre class="example js" title=
+      "Preferring a newer protocol with fallback to an older one">
+        // Ordered by preference; older browsers will skip protocols they
+        // don't know about without throwing an exception.
+        const protocol = [
+          "example-new-protocol",
+          "example-legacy-protocol",
+        ].find(DigitalCredential.userAgentAllowsProtocol);
+
+        if (protocol) {
+          // Use the best protocol this browser supports.
+        } else {
+          // No supported protocol found. Fall back to another approach.
         }
       </pre>
       <h3>

--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
         (detectable via the `typeof` check shown above), protocol identifiers
         are added to {{DigitalCredentialProtocol}} progressively as
         [=user agents=] adopt support for them, so calling this method with an
-        unknown protocol identifier safely returns `false` without [exception/throw|throwing=] an [=exception=].
+        unknown protocol identifier safely returns `false` without [=exception/throw|throwing=] an [=exception=].
         Note that calling this method on a browser where {{DigitalCredential}}
         is not defined will throw a {{ReferenceError}}, so the
         `typeof DigitalCredential !== "undefined"` guard shown above is still
@@ -247,8 +247,8 @@
       </p>
       <pre class="example js" title=
       "Preferring a newer protocol with fallback to an older one">
-        // Ordered by preference; older browsers will skip protocols they
-        // don't know about without throwing an exception.
+        // Ordered by preference; on browsers that implement DigitalCredential,
+        // unknown protocols return false rather than throwing.
         const protocol = [
           "example-new-protocol",
           "example-legacy-protocol",


### PR DESCRIPTION
Closes #470. Expands the usage examples section to explain that protocol identifiers are added to DigitalCredentialProtocol progressively, so the method safely returns false on legacy browsers for unknown protocols. Adds an example showing how to prefer a newer protocol with graceful fallback to an older one using Array.find().


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/484.html" title="Last updated on Apr 17, 2026, 12:56 AM UTC (2f013d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/484/5489f18...2f013d9.html" title="Last updated on Apr 17, 2026, 12:56 AM UTC (2f013d9)">Diff</a>