### PR TITLE
Simplify and clarify core algorithms

### DIFF
--- a/index.html
+++ b/index.html
@@ -793,7 +793,7 @@
       </li>
       <li>Let |validatedRequests| be the result of [=credential request
       coordinator/validate credential requests=] given |requests|. If that
-      [=exception/throws=] an [=exception=] |error|:
+      [=exception/throws=] an [=exception=] |error|, take the following steps:
         <ol>
           <li>[=credential request coordinator/Reject the credential request
           with=] |error| and |promise|.
@@ -802,7 +802,7 @@
           </li>
         </ol>
       </li>
-      <li>If |validatedRequests| [=list/is empty=]:
+      <li>If |validatedRequests| [=list/is empty=], take the following steps:
         <ol>
           <li>[=credential request coordinator/Reject the credential request
           with=] a newly created {{TypeError}} and |promise|.
@@ -811,7 +811,7 @@
           </li>
         </ol>
       </li>
-      <li>If |signal| was passed:
+      <li>If |signal| was passed, take the following steps:
         <ol>
           <li>Assert: |signal| is not [=AbortSignal/aborted=].
             <p class="note">
@@ -1291,8 +1291,8 @@
       underlying platform or provider.
     </p>
     <p>
-      To <dfn>user agent allows protocol</dfn> given a {{DOMString}}
-      |protocol|:
+      To check whether a <dfn>user agent allows protocol</dfn> given a {{DOMString}}
+      |protocol|, take the following steps:
     </p>
     <ol class="algorithm">
       <li>If |protocol| is not an [=enumeration value=] of
@@ -1439,7 +1439,7 @@
       </li>
       <li>[=Consume user activation=] of |global|.
       </li>
-      <li>Let |promise| be [=a new promise=] in [=this=]'s [=relevant realm=].
+      <li>Let |promise| be [=a new promise=] in the [=relevant realm=] of [=this=].
       </li>
       <li>[=credential request coordinator/Prepare credential requests=] with
       |document|, |requests|, |promise|, and |signal|.

--- a/index.html
+++ b/index.html
@@ -786,7 +786,7 @@
       </li>
       <li>Let |validatedRequests| be the result of [=credential request
       coordinator/validate credential requests=] given |requests|. If that
-      [=exception/throws=] an [=exception=] |error|, take the following steps:
+      [=exception/throws=] an [=exception=] |error|, then:
         <ol>
           <li>[=credential request coordinator/Reject the credential request
           with=] |error| and |promise|.
@@ -795,7 +795,7 @@
           </li>
         </ol>
       </li>
-      <li>If |validatedRequests| [=list/is empty=], take the following steps:
+      <li>If |validatedRequests| [=list/is empty=], then:
         <ol>
           <li>[=credential request coordinator/Reject the credential request
           with=] a newly created {{TypeError}} and |promise|.
@@ -804,7 +804,7 @@
           </li>
         </ol>
       </li>
-      <li>If |signal| was passed, take the following steps:
+      <li>If |signal| was passed, then:
         <ol>
           <li>Assert: |signal| is not [=AbortSignal/aborted=].
             <p class="note">

--- a/index.html
+++ b/index.html
@@ -791,6 +791,26 @@
       <li>Set the [=credential request coordinator=]'s [=credential request
       coordinator/active promise=] to |promise|.
       </li>
+      <li>Let |validatedRequests| be the result of [=credential request
+      coordinator/validate credential requests=] given |requests|. If that
+      [=exception/throws=] an [=exception=] |error|:
+        <ol>
+          <li>[=credential request coordinator/Reject the credential request
+          with=] |error| and |promise|.
+          </li>
+          <li>Return.
+          </li>
+        </ol>
+      </li>
+      <li>If |validatedRequests| [=list/is empty=]:
+        <ol>
+          <li>[=credential request coordinator/Reject the credential request
+          with=] a newly created {{TypeError}} and |promise|.
+          </li>
+          <li>Return.
+          </li>
+        </ol>
+      </li>
       <li>If |signal| was passed:
         <ol>
           <li>Assert: |signal| is not [=AbortSignal/aborted=].
@@ -817,37 +837,6 @@
           coordinator/abort algorithm=] to |abortAlgorithm|.
           </li>
           <li>[=AbortSignal/Add=] |abortAlgorithm| to |signal|.
-          </li>
-        </ol>
-      </li>
-      <li>Let |validatedRequests| be the result of [=credential request
-      coordinator/validate credential requests=] given |requests|. If that
-      [=exception/throws=] an [=exception=] |error|:
-        <ol>
-          <li>[=credential request coordinator/Reject the credential request
-          with=] |error| and |promise|.
-          </li>
-          <li>Return.
-          </li>
-        </ol>
-      </li>
-      <li>If |validatedRequests| [=list/is empty=]:
-        <ol>
-          <li>[=credential request coordinator/Reject the credential request
-          with=] a newly created {{TypeError}} and |promise|.
-          </li>
-          <li>Return.
-          </li>
-        </ol>
-      </li>
-      <li>If |signal| was passed and |signal| is [=AbortSignal/aborted=]:
-        <ol>
-          <li>Let |error| be |signal|'s [=AbortSignal/abort reason=].
-          </li>
-          <li>[=credential request coordinator/Reject the credential request
-          with=] |error| and |promise|.
-          </li>
-          <li>Return.
           </li>
         </ol>
       </li>
@@ -888,8 +877,8 @@
           |protocol| does not equal any [=enumeration value=] in
           {{DigitalCredentialIssuanceProtocol}}, [=iteration/continue=].
           </li>
-          <li>If the [=user agent=] does not allow |protocol|,
-          [=iteration/continue=].
+          <li>If [=user agent allows protocol=] given |protocol| returns
+          `false`, [=iteration/continue=].
           </li>
           <li>Let |data| be |request|'s {{DigitalCredentialGetRequest/data}},
           if |request| is a {{DigitalCredentialGetRequest}}, or |request|'s
@@ -1302,8 +1291,8 @@
       underlying platform or provider.
     </p>
     <p>
-      When this method is invoked, the user agent MUST execute the following
-      algorithm:
+      To <dfn>user agent allows protocol</dfn> given a {{DOMString}}
+      |protocol|:
     </p>
     <ol class="algorithm">
       <li>If |protocol| is not an [=enumeration value=] of
@@ -1313,6 +1302,10 @@
       `false`.
       </li>
     </ol>
+    <p>
+      When this method is invoked, the user agent MUST return the result of
+      [=user agent allows protocol=] given |protocol|.
+    </p>
     <h3>
       Supporting Data Structures
     </h3>
@@ -1446,7 +1439,7 @@
       </li>
       <li>[=Consume user activation=] of |global|.
       </li>
-      <li>Let |promise| be [=a new promise=].
+      <li>Let |promise| be [=a new promise=] in [=this=]'s [=relevant realm=].
       </li>
       <li>[=credential request coordinator/Prepare credential requests=] with
       |document|, |requests|, |promise|, and |signal|.


### PR DESCRIPTION
Closes #N/A

Reorders `prepare credential requests` to validate requests before
registering the abort signal handler, removing the now-unreachable
post-validation abort check. Extracts the steps of
`userAgentAllowsProtocol()` into a new internal abstract operation,
`user agent allows protocol`, so both the static method and
`validate credential requests` invoke it directly — avoiding a public
JS method in the internal algorithm call graph. Fixes missing realm
qualifier on the new promise in `[[Create]]`.

The following tasks have been completed:

- [x] ~~Modified Web platform tests~~ — no observable behaviour change

Implementation commitment:

- [x] WebKit — already implemented; `CredentialRequestCoordinator::prepareCredentialRequest()` validates before registering abort signal handler, `userAgentAllowsProtocol()` is separate from validation path
- [x] Chromium — already implemented; `DiscoverDigitalIdentityCredentialFromExternalSource()` and `CreateDigitalIdentityCredentialInExternalSource()` both validate before `signal->AddAlgorithm()`, `userAgentAllowsProtocol()` is separate from validation path
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/491.html" title="Last updated on Apr 14, 2026, 1:18 AM UTC (b545abe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/491/f6f59ce...b545abe.html" title="Last updated on Apr 14, 2026, 1:18 AM UTC (b545abe)">Diff</a>