### PR TITLE
Add Request/Respose Tampering Security Considerations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1528,15 +1528,13 @@
       <p>
         The sections that follow describe the API's security properties, the
         threats in scope, the assumptions on which security depends, and
-        residual threats that remain after the mitigations are applied. This
-        specification defines requirements for the user agent's behavior only
-        when mediating [=digital credential/credential responses=].
+        residual threats that remain after the mitigations are applied.
       </p>
       <p class="note">
-        Other security considerations that depend on protocols, wallet
-        implementations, operating systems, or transport security are described
-        as expectations or preconditions, but these are not normatively
-        required by this specification unless already normatively specified.
+        Security considerations that depend on wallet implementations,
+        operating systems, or transport security are described as expectations
+        or preconditions, but these are not normatively required by this
+        specification.
       </p>
       <h3 class="informative">
         Threat Model
@@ -1559,14 +1557,12 @@
       </p>
       <dl>
         <dt>
-          <dfn data-local-lt="tampering">Tampering requests through the
-          networks</dfn>
+          <dfn data-local-lt="tampering">Network Tampering</dfn>
         </dt>
         <dd>
-          An attacker attempts to alter attacker that can inject or modify page
-          content in an insecure context attempts to alter a
-          {{DigitalCredentialGetRequest}} or {{DigitalCredentialCreateRequest}}
-          on the wire.
+          A network attacker injects or modifies page content in an insecure
+          context, altering a {{DigitalCredentialGetRequest}} or
+          {{DigitalCredentialCreateRequest}} in transit.
         </dd>
         <dt>
           <dfn>Unauthorized Cross-Origin Access</dfn>
@@ -1593,8 +1589,8 @@
           <dfn>Request Tampering</dfn>
         </dt>
         <dd>
-          Modification of a [=digital credential/presentation protocols=] or
-          [=digital credential/issuance protocols=] request after it is
+          Modification of a [=digital credential/presentation protocol=] or
+          [=digital credential/issuance protocol=] request after it is
           created. This threat is expected to be addressed by the underlying
           exchange protocol; for example, through signing and validating
           requests.
@@ -1603,11 +1599,11 @@
           <dfn>Response Tampering</dfn>
         </dt>
         <dd>
-          Modification of a [=digital credential/presentation protocols=] or
-          [=digital credential/issuance protocols=] response after it is
+          Modification of a [=digital credential/presentation protocol=] or
+          [=digital credential/issuance protocol=] response after it is
           created. This threat is expected to be addressed by the underlying
           exchange protocol; for example, through signing and validating
-          requests.
+          responses.
         </dd>
       </dl>
       <h3 class="informative">
@@ -1659,25 +1655,27 @@
         Request Integrity
       </h4>
       <p>
-        Protocols used with this API MUST define mechanisms that allow all the
-        parties to determine that a request was not modified. In general, this
-        is expected to be achieved by signing the request at the exchange
-        protocol level, and the receiving party is expected to verify it.
+        A user agent MUST NOT support a [=digital credential/presentation
+        protocol=] or [=digital credential/issuance protocol=] unless the
+        protocol defines mechanisms that allow all parties to determine that
+        a request has not been modified after creation. In general, this is
+        achieved by signing the request at the protocol level.
       </p>
       <p>
-        These mechanisms reduce [=request tampering=] at protocol level.
+        These mechanisms reduce [=request tampering=] at the protocol level.
       </p>
       <h4>
         Response Integrity
       </h4>
       <p>
-        Protocols used with this API MUST define mechanisms that allow all the
-        parties to determine that the response was not modified. In general,
-        this is expected to be achieved by signing the response at the exchange
-        protocol level, and the receiving party is expected to verify it.
+        A user agent MUST NOT support a [=digital credential/presentation
+        protocol=] or [=digital credential/issuance protocol=] unless the
+        protocol defines mechanisms that allow all parties to determine that
+        a response has not been modified after creation. In general, this is
+        achieved by signing the response at the protocol level.
       </p>
       <p>
-        These mechanisms reduce [=Response Tampering=] at protocol level.
+        These mechanisms reduce [=response tampering=] at the protocol level.
       </p>
     </section>
     <section class="informative" data-cite="privacy-principles">

--- a/index.html
+++ b/index.html
@@ -1564,8 +1564,8 @@
           <dfn data-local-lt="tampering">Network Tampering</dfn>
         </dt>
         <dd>
-          A network attacker injects or modifies page content in an insecure
-          context, altering a {{DigitalCredentialGetRequest}} or
+          An attacker on the network attempts to inject or modify page content
+          to alter a {{DigitalCredentialGetRequest}} or
           {{DigitalCredentialCreateRequest}} in transit.
         </dd>
         <dt>

--- a/index.html
+++ b/index.html
@@ -1566,7 +1566,10 @@
         <dd>
           An attacker on the network attempts to inject or modify page content
           to alter a {{DigitalCredentialGetRequest}} or
-          {{DigitalCredentialCreateRequest}} in transit.
+          {{DigitalCredentialCreateRequest}} in transit. Transport security
+          (enforced via [=secure contexts=]) mitigates this threat. This is
+          distinct from [=data tampering=], which occurs at the protocol level
+          after message creation.
         </dd>
         <dt>
           <dfn>Unauthorized Cross-Origin Access</dfn>
@@ -1594,10 +1597,13 @@
         </dt>
         <dd>
           Modification of a [=digital credential/presentation protocol=] or
-          [=digital credential/issuance protocol=] request or response after it
-          is created. This threat is expected to be addressed by the underlying
-          exchange protocol; for example, through signing and validating
-          requests and responses.
+          [=digital credential/issuance protocol=] request or response by a
+          [=verifier=], [=issuer=], [=holder=], or other party in the exchange
+          after the message is created. Unlike [=network tampering=], this
+          threat occurs at the protocol level and is not mitigated by transport
+          security alone. This threat is expected to be addressed by the
+          underlying exchange protocol; for example, through signing and
+          validating requests and responses.
         </dd>
       </dl>
       <h3>
@@ -1644,6 +1650,17 @@
         protocols intended to be used with this API define the additional
         security properties, trust relationships, and mitigations needed to
         protect the request and response beyond the user agent boundary.
+      </p>
+      <p>
+        This API mediates access to digital credentials, including
+        government-issued documents (see [[#abstract]]). Such exchanges involve
+        [=issuers=], [=holders=], and [=verifiers=], each of which may
+        introduce integrity risks that the user agent cannot detect at runtime.
+        The user agent determines whether a protocol is supported (via
+        {{DigitalCredential/userAgentAllowsProtocol()}}), but cannot inspect
+        the cryptographic integrity of individual exchanges. The requirements
+        below address this by gating protocol support on whether the protocol
+        defines adequate integrity mechanisms.
       </p>
       <h4>
         Request and Response Integrity

--- a/index.html
+++ b/index.html
@@ -1536,7 +1536,7 @@
         or preconditions, but these are not normatively required by this
         specification.
       </p>
-      <h3 class="informative">
+      <h3>
         Threat Model
       </h3>
       <p>
@@ -1590,10 +1590,9 @@
         </dt>
         <dd>
           Modification of a [=digital credential/presentation protocol=] or
-          [=digital credential/issuance protocol=] request after it is
-          created. This threat is expected to be addressed by the underlying
-          exchange protocol; for example, through signing and validating
-          requests.
+          [=digital credential/issuance protocol=] request after it is created.
+          This threat is expected to be addressed by the underlying exchange
+          protocol; for example, through signing and validating requests.
         </dd>
         <dt>
           <dfn>Response Tampering</dfn>
@@ -1606,7 +1605,7 @@
           responses.
         </dd>
       </dl>
-      <h3 class="informative">
+      <h3>
         Security Considerations for the User Agent
       </h3>
       <p>
@@ -1657,8 +1656,8 @@
       <p>
         A user agent MUST NOT support a [=digital credential/presentation
         protocol=] or [=digital credential/issuance protocol=] unless the
-        protocol defines mechanisms that allow all parties to determine that
-        a request has not been modified after creation. In general, this is
+        protocol defines mechanisms that allow all parties to determine that a
+        request has not been modified after creation. In general, this is
         achieved by signing the request at the protocol level.
       </p>
       <p>
@@ -1670,8 +1669,8 @@
       <p>
         A user agent MUST NOT support a [=digital credential/presentation
         protocol=] or [=digital credential/issuance protocol=] unless the
-        protocol defines mechanisms that allow all parties to determine that
-        a response has not been modified after creation. In general, this is
+        protocol defines mechanisms that allow all parties to determine that a
+        response has not been modified after creation. In general, this is
         achieved by signing the response at the protocol level.
       </p>
       <p>

--- a/index.html
+++ b/index.html
@@ -1651,30 +1651,19 @@
         protect the request and response beyond the user agent boundary.
       </p>
       <h4>
-        Request Integrity
+        Request and Response Integrity
       </h4>
       <p>
         A user agent MUST NOT support a [=digital credential/presentation
         protocol=] or [=digital credential/issuance protocol=] unless the
         protocol defines mechanisms that allow all parties to determine that a
-        request has not been modified after creation. In general, this is
-        achieved by signing the request at the protocol level.
+        request or response has not been modified after creation. In general,
+        this is achieved by signing requests and responses at the protocol
+        level.
       </p>
       <p>
-        These mechanisms reduce [=request tampering=] at the protocol level.
-      </p>
-      <h4>
-        Response Integrity
-      </h4>
-      <p>
-        A user agent MUST NOT support a [=digital credential/presentation
-        protocol=] or [=digital credential/issuance protocol=] unless the
-        protocol defines mechanisms that allow all parties to determine that a
-        response has not been modified after creation. In general, this is
-        achieved by signing the response at the protocol level.
-      </p>
-      <p>
-        These mechanisms reduce [=response tampering=] at the protocol level.
+        These mechanisms reduce [=request tampering=] and [=response
+        tampering=] at the protocol level.
       </p>
     </section>
     <section class="informative" data-cite="privacy-principles">

--- a/index.html
+++ b/index.html
@@ -1518,7 +1518,7 @@
         </dd>
       </dl>
     </section>
-    <section class="informative">
+    <section>
       <!--
       // MARK: Security Considerations
       -->
@@ -1538,7 +1538,7 @@
         as expectations or preconditions, but these are not normatively
         required by this specification unless already normatively specified.
       </p>
-      <h3>
+      <h3 class="informative">
         Threat Model
       </h3>
       <p>
@@ -1559,12 +1559,14 @@
       </p>
       <dl>
         <dt>
-          <dfn data-local-lt="tampering">Request Tampering</dfn>
+          <dfn data-local-lt="tampering">Tampering requests through the
+          networks</dfn>
         </dt>
         <dd>
-          A network attacker that can inject or modify page content in an
-          insecure context attempts to alter a {{DigitalCredentialGetRequest}}
-          or {{DigitalCredentialCreateRequest}} before processing.
+          An attacker attempts to alter attacker that can inject or modify page
+          content in an insecure context attempts to alter a
+          {{DigitalCredentialGetRequest}} or {{DigitalCredentialCreateRequest}}
+          on the wire.
         </dd>
         <dt>
           <dfn>Unauthorized Cross-Origin Access</dfn>
@@ -1586,12 +1588,30 @@
         security of credential presentation and issuance. The following defines
         the [=out-of-scope threats=] for this specification:
       </p>
-      <ul>
-        <li>To be written...
-        </li>
-      </ul>
-      <h3>
-        Mitigations
+      <dl>
+        <dt>
+          <dfn>Request Tampering</dfn>
+        </dt>
+        <dd>
+          Modification of a [=digital credential/presentation protocols=] or
+          [=digital credential/issuance protocols=] request after it is
+          created. This threat is expected to be addressed by the underlying
+          exchange protocol; for example, through signing and validating
+          requests.
+        </dd>
+        <dt>
+          <dfn>Response Tampering</dfn>
+        </dt>
+        <dd>
+          Modification of a [=digital credential/presentation protocols=] or
+          [=digital credential/issuance protocols=] response after it is
+          created. This threat is expected to be addressed by the underlying
+          exchange protocol; for example, through signing and validating
+          requests.
+        </dd>
+      </dl>
+      <h3 class="informative">
+        Security Considerations for the User Agent
       </h3>
       <p>
         The following mitigations address [=in-scope threats=] through
@@ -1622,6 +1642,42 @@
         Security Considerations</a> section of the [[[permissions-policy]]]
         specification for additional security properties provided by this
         integration.
+      </p>
+      <h3>
+        Security Considerations for Protocols
+      </h3>
+      <p>
+        This specification defines the user agent's mediation behavior, but it
+        does not by itself provide all of the security properties necessary to
+        guarantee the end-to-end security of digital credentials exchanged
+        through the API. Consequently, this specification assumes that
+        protocols intended to be used with this API define the additional
+        security properties, trust relationships, and mitigations needed to
+        protect the request and response beyond the user agent boundary.
+      </p>
+      <h4>
+        Request Integrity
+      </h4>
+      <p>
+        Protocols used with this API MUST define mechanisms that allow all the
+        parties to determine that a request was not modified. In general, this
+        is expected to be achieved by signing the request at the exchange
+        protocol level, and the receiving party is expected to verify it.
+      </p>
+      <p>
+        These mechanisms reduce [=request tampering=] at protocol level.
+      </p>
+      <h4>
+        Response Integrity
+      </h4>
+      <p>
+        Protocols used with this API MUST define mechanisms that allow all the
+        parties to determine that the response was not modified. In general,
+        this is expected to be achieved by signing the response at the exchange
+        protocol level, and the receiving party is expected to verify it.
+      </p>
+      <p>
+        These mechanisms reduce [=Response Tampering=] at protocol level.
       </p>
     </section>
     <section class="informative" data-cite="privacy-principles">

--- a/index.html
+++ b/index.html
@@ -650,7 +650,11 @@
           </td>
         </tr>
       </tbody>
-    </table><!--
+    </table>
+    <p>
+      See [[[#security-considerations-for-protocols]]] for the security
+      requirements that protocols listed in this table need to meet.
+    </p><!--
     // MARK: Credential Request Coordinator
     -->
     <h2>

--- a/index.html
+++ b/index.html
@@ -1590,23 +1590,14 @@
       </p>
       <dl>
         <dt>
-          <dfn>Request Tampering</dfn>
+          <dfn>Data Tampering</dfn>
         </dt>
         <dd>
           Modification of a [=digital credential/presentation protocol=] or
-          [=digital credential/issuance protocol=] request after it is created.
-          This threat is expected to be addressed by the underlying exchange
-          protocol; for example, through signing and validating requests.
-        </dd>
-        <dt>
-          <dfn>Response Tampering</dfn>
-        </dt>
-        <dd>
-          Modification of a [=digital credential/presentation protocol=] or
-          [=digital credential/issuance protocol=] response after it is
-          created. This threat is expected to be addressed by the underlying
+          [=digital credential/issuance protocol=] request or response after it
+          is created. This threat is expected to be addressed by the underlying
           exchange protocol; for example, through signing and validating
-          responses.
+          requests and responses.
         </dd>
       </dl>
       <h3>
@@ -1666,8 +1657,7 @@
         level.
       </p>
       <p>
-        These mechanisms reduce [=request tampering=] and [=response
-        tampering=] at the protocol level.
+        These mechanisms reduce [=data tampering=] at the protocol level.
       </p>
     </section>
     <section class="informative" data-cite="privacy-principles">

--- a/index.html
+++ b/index.html
@@ -1911,7 +1911,7 @@
         </dd>
       </dl>
     </section>
-    <section>
+    <section class="informative">
       <!--
       // MARK: Security Considerations
       -->

--- a/index.html
+++ b/index.html
@@ -2120,10 +2120,10 @@
       </h4>
       <p>
         A user agent MUST NOT support a [=digital credential/presentation
-        protocol=] or [=digital credential/issuance protocol=] unless the
-        protocol defines mechanisms that allow all parties to determine that a
-        request or response has not been modified after creation. In general,
-        this is achieved by signing requests and responses at the protocol
+        protocol=] or [=digital credential/issuance protocol=] unless the protocol
+        defines mechanisms that allow the recipient of a request or response to
+        determine that it has not been modified after creation by its sender. In
+        general, this is achieved by signing requests and responses at the protocol
         level.
       </p>
       <p>

--- a/index.html
+++ b/index.html
@@ -1997,10 +1997,10 @@
         </dt>
         <dd>
           Modification of a [=digital credential/presentation protocol=] or
-          [=digital credential/issuance protocol=] request or response by a
-          [=verifier=], [=issuer=], [=holder=], or other party in the exchange
-          after the message is created. Unlike [=network tampering=], this
-          threat occurs at the protocol level and is not mitigated by transport
+          [=digital credential/issuance protocol=] request or response by an attacker
+          or intermediary (including a [=verifier=], [=issuer=], or [=holder=]) after
+          it is created by its sender. Unlike [=network tampering=], this threat
+          occurs at the protocol level and is not mitigated by transport
           security alone. This threat is expected to be addressed by the
           underlying exchange protocol; for example, through signing and
           validating requests and responses.


### PR DESCRIPTION
Closes #479

Adds request and response tampering to the threat model and establishes normative integrity requirements for protocols used with the Digital Credentials API.

## Why this matters

The DC API mediates access to digital credentials, including government-issued identity documents. It defines the user agent's mediation behavior, but does not by itself guarantee the end-to-end security of credential exchanges. That depends on the underlying protocols.

Without normative integrity requirements, the spec is silent on whether a protocol must protect requests and responses from modification. This gap leaves users exposed to tampering attacks at the protocol level, which the user agent cannot detect or prevent after handoff.

[RFC 7258](https://www.rfc-editor.org/rfc/rfc7258) (BCP 188) established the IETF consensus that known attacks must be mitigated in protocol design: "pervasive monitoring is a technical attack that should be mitigated in the design of IETF protocols, where possible." The same design principle applies to integrity attacks on credential exchanges. The W3C [Ethical Web Principles](https://www.w3.org/TR/ethical-web-principles/#expression) (§2.6) cite RFC 7258 directly: "Our work should not enable state censorship, surveillance or other practices that seek to limit this freedom."

This PR applies that principle: a user agent MUST NOT support a protocol that lacks integrity mechanisms for requests and responses.

## Changes

- Define Request Tampering and Response Tampering as out-of-scope threats (addressed by protocols, not by this API).
- Add normative requirement: a user agent MUST NOT support a protocol unless it defines mechanisms for request and response integrity.
- Rename "Tampering requests through the networks" to "Network Tampering" to distinguish the in-scope network-level threat from protocol-level tampering.
- Cross-reference the [Protocols](https://w3c-fedid.github.io/digital-credentials/#protocols) section to the new security requirements.

The following tasks have been completed:

- [x] ~~Modified Web platform tests~~ — no observable behavior change

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [x] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev

Follow-up from: #487


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/493.html" title="Last updated on Aug 27, 2026, 6:57 AM UTC (585b91b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/493/0aea14a...585b91b.html" title="Last updated on Aug 27, 2026, 6:57 AM UTC (585b91b)">Diff</a>