### PR TITLE
editorial: remove threat model issue marker and fix stale reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,13 +58,6 @@
           date: "2025-03-26",
           publisher: "W3C"
         },
-        "threat-model-decentralized-identities": {
-          title: "Threat Model for Decentralized Identities",
-          href: "https://github.com/w3c-cg/threat-modeling/blob/main/models/decentralized-identities.md",
-          authors: ["Simone Onofri"],
-          date: "2025-05-28",
-          publisher: "W3C"
-        },
         "custom-schemes": {
           title: "Concerns with custom schemes for identity presentment",
           href: "https://github.com/w3c-fedid/digital-credentials/blob/main/custom-schemes.md",
@@ -1545,7 +1538,6 @@
         The threat model for this specification includes threats to this API
         and to adjacent standards of the ecosystem.
       </p>
-      <p class="issue" data-number="440"></p>
       <p>
         For this specification, threats fall into two categories: [=in-scope
         threats=] and [=out-of-scope threats=].
@@ -1650,7 +1642,7 @@
       <ul>
         <li>[[[credential-considerations]]]
         </li>
-        <li>[[[threat-model-decentralized-identities]]]
+        <li>[[[threat-model-decentralized-credentials]]]
         </li>
         <li>
           <a data-cite="vc-data-model#privacy-considerations">VC Data Model


### PR DESCRIPTION
Closes #440

The threat model for this API lives in the spec's own Security Considerations section, built out by PRs #424, #480, and #481. There's no need for a separate external document — removes the issue marker.

Also drops the local biblio override for the SING threat model — it's now [published as a W3C Group Note Draft](https://www.w3.org/TR/threat-model-decentralized-credentials/) and available in specref. Updates the reference key to match.

The following tasks have been completed:

- [x] ~~Modified Web platform tests~~ — editorial only, no observable change

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/496.html" title="Last updated on Apr 10, 2026, 8:15 AM UTC (a96fe2d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/496/c381c8f...a96fe2d.html" title="Last updated on Apr 10, 2026, 8:15 AM UTC (a96fe2d)">Diff</a>