### PR TITLE
chore: use ReSpec v36 CDDL inline references

### DIFF
--- a/index.html
+++ b/index.html
@@ -2514,17 +2514,17 @@
               }
           </pre>
           <p>
-            The `digitalCredentials.VirtualWalletAction` type represents the
+            The {^ digitalCredentials.VirtualWalletAction ^} type represents the
             different types of virtual wallet actions.
           </p>
           <ul>
-            <li>`"decline"`: The virtual wallet simulates a user cancellation
+            <li>{^ digitalCredentials.VirtualWalletAction/"decline" ^}: The virtual wallet simulates a user cancellation
             or rejection, aborting the request.
             </li>
-            <li>`"respond"`: The virtual wallet simulates a successful user
+            <li>{^ digitalCredentials.VirtualWalletAction/"respond" ^}: The virtual wallet simulates a successful user
             interaction and returns the predefined credential response.
             </li>
-            <li>`"wait"`: The virtual wallet simulates an active, pending
+            <li>{^ digitalCredentials.VirtualWalletAction/"wait" ^}: The virtual wallet simulates an active, pending
             prompt, effectively leaving the active promise unsettled to test
             timeouts or concurrent request handling.
             </li>
@@ -2652,6 +2652,7 @@
     </section>
     <section class="prefer-full-spec-title" id="index"></section>
     <section id="idl-index"></section>
+    <section id="cddl-index"></section>
     <section id="conformance"></section>
     <h2 class="appendix">
       Acknowledgements


### PR DESCRIPTION
## Summary

- Replace plain-text CDDL type references in prose with `{^ ^}` inline syntax for auto-linking to CDDL definitions (ReSpec v36 feature)
- Add `<section id="cddl-index">` for auto-populated CDDL index grouped by module

No normative text changes. Algorithm steps and string comparisons are untouched.

## What changes

| Before | After |
|--------|-------|
| `` `digitalCredentials.VirtualWalletAction` `` | `{^ digitalCredentials.VirtualWalletAction ^}` |
| `` `"decline"` `` | `{^ digitalCredentials.VirtualWalletAction/"decline" ^}` |
| `` `"respond"` `` | `{^ digitalCredentials.VirtualWalletAction/"respond" ^}` |
| `` `"wait"` `` | `{^ digitalCredentials.VirtualWalletAction/"wait" ^}` |


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/502.html" title="Last updated on Apr 23, 2026, 8:58 AM UTC (e53613b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/502/209cbd2...e53613b.html" title="Last updated on Apr 23, 2026, 8:58 AM UTC (e53613b)">Diff</a>