### PR TITLE
editorial: fix closure capture, parameter type, and grammar

### DIFF
--- a/index.html
+++ b/index.html
@@ -845,7 +845,8 @@
           <li>Set the [=credential request coordinator=]'s [=credential request
           coordinator/abort signal=] to |signal|.
           </li>
-          <li>Let |abortAlgorithm| be the following algorithm:
+          <li>Let |abortAlgorithm| be the following algorithm, closing over
+          |signal|:
             <ol>
               <li>If the [=credential request coordinator=]'s [=credential
               request coordinator/active promise=] is not |promise|, return.
@@ -955,8 +956,7 @@
     </h3>
     <p>
       To <dfn data-dfn-for="credential request coordinator">abort the
-      credential request</dfn> given a JavaScript value or {{DOMException}}
-      |error|:
+      credential request</dfn> given a JavaScript value |error|:
     </p>
     <ol class="algorithm">
       <li>If the [=credential request coordinator=]'s [=credential request
@@ -1072,7 +1072,7 @@
     <p>
       Additionally, the API also allows [=digital credential/Issuance
       request|requesting issuance=] of a [=digital credential=], which
-      initiates an mediated issuance flow between the user agent and/or a
+      initiates a mediated issuance flow between the user agent and/or a
       [=holder=]. This is done by calling the
       `navigator.credentials.`{{CredentialsContainer/create()}} method, which
       runs the [=create a credential=] algorithm of

--- a/index.html
+++ b/index.html
@@ -910,7 +910,7 @@
           coordinator/abort signal=] to |signal|.
           </li>
           <li>Let |abortAlgorithm| be the following algorithm, closing over
-          |signal|:
+          |promise| and |signal|:
             <ol>
               <li>If the [=credential request coordinator=]'s [=credential
               request coordinator/active promise=] is not |promise|, return.


### PR DESCRIPTION
Closes #394 (partially — editorial cleanup)

- Make the abort algorithm closure explicitly close over the `|promise|` and `|signal|`, clarifying that `|signal|`'s abort reason is captured from the enclosing scope
- Simplify the `abort the credential request` parameter type from "a JavaScript value or DOMException" to "a JavaScript value" (DOMException is already a JavaScript value)
- Fix article grammar: "an mediated" → "a mediated"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/505.html" title="Last updated on Jul 16, 2026, 8:26 AM UTC (815ed75)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/505/a846942...815ed75.html" title="Last updated on Jul 16, 2026, 8:26 AM UTC (815ed75)">Diff</a>