### PR TITLE
editorial: link defined terms and fix broken dfn scope

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,8 +128,8 @@
       </li>
       <li>Assume opaque (i.e., encrypted) [=digital credential/presentation
       responses=] and [=digital credential/issuance responses=], enabling
-      [=issuers=], [=verifiers=], and [=holders=] to control where potentially sensitive
-      personally identifiable information is exposed.
+      [=issuers=], [=verifiers=], and [=holders=] to control where potentially
+      sensitive personally identifiable information is exposed.
       </li>
       <li>Ensure that all credential interactions are user-mediated, giving
       users control and consent over the [=digital
@@ -371,12 +371,12 @@
       <p>
         The specification allows usage of the API for presenting credentials
         from a remote/third-party origin via the
-        <a>"digital-credentials-get"</a> [=policy-controlled feature=]. This is useful for
-        scenarios where a website wants to request digital credentials from a
-        verification service that is hosted on a different origin. The
-        Permissions Policy can be set on an iframe that embeds the website that
-        wants to use the API. Here is an example of how the Permissions Policy
-        can be set on an iframe:
+        <a>"digital-credentials-get"</a> [=policy-controlled feature=]. This is
+        useful for scenarios where a website wants to request digital
+        credentials from a verification service that is hosted on a different
+        origin. The Permissions Policy can be set on an iframe that embeds the
+        website that wants to use the API. Here is an example of how the
+        Permissions Policy can be set on an iframe:
       </p>
       <pre class="example html" title=
       "Requesting a digital credential across origins">
@@ -390,9 +390,9 @@
       <p>
         Similarly, the specification allows usage of the API for issuing
         credentials from a remote/third-party origin via the
-        <a>"digital-credentials-create"</a> [=policy-controlled feature=]. This is useful
-        for scenarios where a website wants to request issuance of a digital
-        credential using an issuance service on a different origin. The
+        <a>"digital-credentials-create"</a> [=policy-controlled feature=]. This
+        is useful for scenarios where a website wants to request issuance of a
+        digital credential using an issuance service on a different origin. The
         Permissions Policy can be set on an iframe embedding the [=issuer's=]
         interface. Here is an example:
       </p>
@@ -707,11 +707,11 @@
       "credential request coordinator">active promise</dfn>, which the user
       agent initializes as `null`. Through this {{Promise}}, the
       [=coordinator=] reflects the state of the asynchronous [=digital
-      credential/credential request=] workflow to script and either [=resolves=] with a [=digital
-      credential/credential response=] when the interaction completes
-      successfully, or [=rejects=] when processing fails, when the user cancels
-      the request via the UI, or when script aborts the operation via an
-      {{AbortSignal}}.
+      credential/credential request=] workflow to script and either
+      [=resolves=] with a [=digital credential/credential response=] when the
+      interaction completes successfully, or [=rejects=] when processing fails,
+      when the user cancels the request via the UI, or when script aborts the
+      operation via an {{AbortSignal}}.
     </p>
     <p>
       The [=credential request coordinator=] maintains an <dfn data-dfn-for=
@@ -730,10 +730,10 @@
       <li>Validates and transforms presentation or issuance inputs and outputs.
       </li>
       <li>Requests the platform to display, for user selection, the credentials
-      that are available for the current request and/or the [=holders=] that can
-      handle the current request. The availability of credentials and [=holders=]
-      is determined by matching the request parameters, user consent, and
-      platform policy.
+      that are available for the current request and/or the [=holders=] that
+      can handle the current request. The availability of credentials and
+      [=holders=] is determined by matching the request parameters, user
+      consent, and platform policy.
       </li>
       <li>Manages [=resolve|resolution=] or [=reject|rejection=] of the
       [=credential request coordinator/active promise=] based on the
@@ -773,8 +773,8 @@
         "<dfn data-dfn-for="credential request coordinator">requesting</dfn>":
       </dt>
       <dd>
-        A [=digital credential/credential request=] is in progress and the user interface is
-        presented.
+        A [=digital credential/credential request=] is in progress and the user
+        interface is presented.
       </dd>
       <dt>
         "<dfn data-dfn-for="credential request coordinator">aborting</dfn>":
@@ -1397,8 +1397,8 @@
       The {{DigitalCredentialCreateRequest}} dictionary represents an [=digital
       credential/issuance request=]. It is used to specify an [=digital
       credential/issuance protocol=] and some [=digital credential/issuance
-      request data=], to communicate the issuance request between the [=issuer=]
-      and the [=holder=].
+      request data=], to communicate the issuance request between the
+      [=issuer=] and the [=holder=].
     </p>
     <pre class="idl">
     dictionary DigitalCredentialCreateRequest {
@@ -2339,8 +2339,8 @@
           purposes those credentials are able to be used. All parties involved
           in the exchange, whether they are legally obliged to do so or not,
           are advised to support any government [=verifier=] authentication
-          schemes, if they exist. The support for (and integration of) [=verifier=]
-          authentication schemes such as <a href=
+          schemes, if they exist. The support for (and integration of)
+          [=verifier=] authentication schemes such as <a href=
           "https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/docs/annexes/annex-2/annex-2-high-level-requirements.md#a2327-topic-27---registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties">
           EUDI access and registration certificates</a> can mitigate risks of
           proliferation of unnecessary credential requests. However, the
@@ -2462,8 +2462,8 @@
           Reporting abuse
         </h5>
         <p class="issue" data-number="267">
-          Consider an interoperable abuse reporting system for [=verifiers=] making
-          unnecessary and abusive requests.
+          Consider an interoperable abuse reporting system for [=verifiers=]
+          making unnecessary and abusive requests.
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
     };
     </script>
   </head>
-  <body data-cite="credential-management vc-data-model">
+  <body data-cite="credential-management permissions-policy vc-data-model">
     <section id="abstract">
       <p>
         This document specifies an API enabling [=user agents=] to mediate the
@@ -706,8 +706,8 @@
       The [=credential request coordinator=] maintains an <dfn data-dfn-for=
       "credential request coordinator">active promise</dfn>, which the user
       agent initializes as `null`. Through this {{Promise}}, the
-      [=coordinator=] reflects the state of the asynchronous [=credential
-      request=] workflow to script and either [=resolves=] with a [=digital
+      [=coordinator=] reflects the state of the asynchronous [=digital
+      credential/credential request=] workflow to script and either [=resolves=] with a [=digital
       credential/credential response=] when the interaction completes
       successfully, or [=rejects=] when processing fails, when the user cancels
       the request via the UI, or when script aborts the operation via an
@@ -759,21 +759,21 @@
     <p>
       The [=credential request coordinator=] has a finite set of
       <dfn data-dfn-for="credential request coordinator">interaction
-      states</dfn>, which are used to manage the lifecycle of a [=credential
-      request=]:
+      states</dfn>, which are used to manage the lifecycle of a [=digital
+      credential/credential request=]:
     </p>
     <dl>
       <dt>
         "<dfn data-dfn-for="credential request coordinator">idle</dfn>":
       </dt>
       <dd>
-        No [=credential request=] is currently in progress.
+        No [=digital credential/credential request=] is currently in progress.
       </dd>
       <dt>
         "<dfn data-dfn-for="credential request coordinator">requesting</dfn>":
       </dt>
       <dd>
-        A [=credential request=] is in progress and the user interface is
+        A [=digital credential/credential request=] is in progress and the user interface is
         presented.
       </dd>
       <dt>

--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
       </li>
       <li>Assume opaque (i.e., encrypted) [=digital credential/presentation
       responses=] and [=digital credential/issuance responses=], enabling
-      issuers, verifiers, and holders to control where potentially sensitive
+      [=issuers=], [=verifiers=], and [=holders=] to control where potentially sensitive
       personally identifiable information is exposed.
       </li>
       <li>Ensure that all credential interactions are user-mediated, giving
@@ -371,7 +371,7 @@
       <p>
         The specification allows usage of the API for presenting credentials
         from a remote/third-party origin via the
-        <a>"digital-credentials-get"</a> Permissions Policy. This is useful for
+        <a>"digital-credentials-get"</a> [=policy-controlled feature=]. This is useful for
         scenarios where a website wants to request digital credentials from a
         verification service that is hosted on a different origin. The
         Permissions Policy can be set on an iframe that embeds the website that
@@ -390,10 +390,10 @@
       <p>
         Similarly, the specification allows usage of the API for issuing
         credentials from a remote/third-party origin via the
-        <a>"digital-credentials-create"</a> Permissions Policy. This is useful
+        <a>"digital-credentials-create"</a> [=policy-controlled feature=]. This is useful
         for scenarios where a website wants to request issuance of a digital
         credential using an issuance service on a different origin. The
-        Permissions Policy can be set on an iframe embedding the issuer's
+        Permissions Policy can be set on an iframe embedding the [=issuer's=]
         interface. Here is an example:
       </p>
       <pre class="example html" title=
@@ -512,7 +512,7 @@
         credential/issuance response=].
       </dd>
       <dt>
-        <dfn data-for="digital credential">Credential request</dfn>
+        <dfn data-dfn-for="digital credential">Credential request</dfn>
       </dt>
       <dd>
         A [=digital credential/presentation request=] or an [=digital
@@ -730,8 +730,8 @@
       <li>Validates and transforms presentation or issuance inputs and outputs.
       </li>
       <li>Requests the platform to display, for user selection, the credentials
-      that are available for the current request and/or the holders that can
-      handle the current request. The availability of credentials and holders
+      that are available for the current request and/or the [=holders=] that can
+      handle the current request. The availability of credentials and [=holders=]
       is determined by matching the request parameters, user consent, and
       platform policy.
       </li>
@@ -1312,7 +1312,7 @@
       The <dfn data-dfn-for="DigitalCredentialRequestOptions">requests</dfn>
       specify an [=digital credential/presentation protocol=] and [=digital
       credential/presentation request data=], which the user agent MAY match
-      against a holder's software, such as a digital wallet.
+      against a [=holder's=] software, such as a digital wallet.
     </p><!--
     // MARK: DigitalCredentialGetRequest
     -->
@@ -1324,7 +1324,7 @@
       credential/presentation request=]. It is used to specify an [=digital
       credential/presentation protocol=] and some [=digital
       credential/presentation request data=], which the user agent MAY match
-      against software used by a holder, such as a digital wallet.
+      against software used by a [=holder=], such as a digital wallet.
     </p>
     <pre class="idl">
       dictionary DigitalCredentialGetRequest {
@@ -1341,7 +1341,7 @@
     </p>
     <p>
       The {{DigitalCredentialGetRequest/protocol}} member's value is one of the
-      protocol identifiers defined in
+      [=digital credential/protocol identifiers=] defined in
       {{DigitalCredentialPresentationProtocol}}.
     </p>
     <h4>
@@ -1350,7 +1350,7 @@
     <p>
       The <dfn data-dfn-for="DigitalCredentialGetRequest">data</dfn> member is
       the [=digital credential/presentation request data=] to be handled by the
-      holder's credential provider, such as a digital identity wallet.
+      [=holder's=] credential provider, such as a digital identity wallet.
     </p><!--
     // MARK: CredentialCreationOptions
     -->
@@ -1397,8 +1397,8 @@
       The {{DigitalCredentialCreateRequest}} dictionary represents an [=digital
       credential/issuance request=]. It is used to specify an [=digital
       credential/issuance protocol=] and some [=digital credential/issuance
-      request data=], to communicate the issuance request between the issuer
-      and the holder.
+      request data=], to communicate the issuance request between the [=issuer=]
+      and the [=holder=].
     </p>
     <pre class="idl">
     dictionary DigitalCredentialCreateRequest {
@@ -1415,7 +1415,7 @@
     </p>
     <p>
       The {{DigitalCredentialCreateRequest/protocol}} member's value is one of
-      the protocol identifiers defined in
+      the [=digital credential/protocol identifiers=] defined in
       {{DigitalCredentialIssuanceProtocol}}.
     </p>
     <h4>
@@ -1424,7 +1424,7 @@
     <p>
       The <dfn data-dfn-for="DigitalCredentialCreateRequest">data</dfn> member
       is the [=digital credential/issuance request data=] to be handled by the
-      holder's credential provider, such as a digital identity wallet.
+      [=holder's=] credential provider, such as a digital identity wallet.
     </p><!--
     // MARK: DigitalCredential interface
     -->
@@ -2339,7 +2339,7 @@
           purposes those credentials are able to be used. All parties involved
           in the exchange, whether they are legally obliged to do so or not,
           are advised to support any government [=verifier=] authentication
-          schemes, if they exist. The support for (and integration of) verifier
+          schemes, if they exist. The support for (and integration of) [=verifier=]
           authentication schemes such as <a href=
           "https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/docs/annexes/annex-2/annex-2-high-level-requirements.md#a2327-topic-27---registration-of-pid-providers-providers-of-qeaas-pub-eaas-and-non-qualified-eaas-and-relying-parties">
           EUDI access and registration certificates</a> can mitigate risks of
@@ -2462,7 +2462,7 @@
           Reporting abuse
         </h5>
         <p class="issue" data-number="267">
-          Consider an interoperable abuse reporting system for verifiers making
+          Consider an interoperable abuse reporting system for [=verifiers=] making
           unnecessary and abusive requests.
         </p>
       </section>


### PR DESCRIPTION
Closes #394

The following tasks have been completed:

- [ ] Modified Web platform tests — editorial only, no observable change

Implementation commitment:

- [ ] WebKit (editorial, no implementation change)
- [ ] Chromium (editorial, no implementation change)
- [ ] Gecko (editorial, no implementation change)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev

## Summary

- Fix `data-for` → `data-dfn-for` on "Credential request" `<dfn>` (was silently breaking ReSpec scoping)
- Scope bare `[=credential request=]` references to `[=digital credential/credential request=]` (required after the dfn scope fix)
- Link ~15 unlinked `holder`/`holders` occurrences throughout normative sections
- Link unlinked `verifier`/`verifiers` occurrences in privacy considerations
- Link unlinked `issuer` in issuance examples section
- Link "protocol identifiers" to `digital credential/protocol identifier` definition
- Replace "Permissions Policy" with linked `[=policy-controlled feature=]` and add `permissions-policy` to body `data-cite`

All changes are editorial — no substantive text modifications. Zero ReSpec errors after changes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/507.html" title="Last updated on Apr 30, 2026, 6:42 AM UTC (a3aa297)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/507/0bbd3e3...a3aa297.html" title="Last updated on Apr 30, 2026, 6:42 AM UTC (a3aa297)">Diff</a>