### PR TITLE
Remove "origin bound" declaration from DigitalCredential

### DIFF
--- a/index.html
+++ b/index.html
@@ -1462,9 +1462,6 @@
       static boolean userAgentAllowsProtocol(DOMString protocol);
     };
     </pre>
-    <p>
-      {{DigitalCredential}} instances are [=Credential/origin bound=].
-    </p>
     <h4>
       The `protocol` member
     </h4>


### PR DESCRIPTION
Closes #508

The `[[origin]]` internal slot provides no security benefit for `DigitalCredential` because:

- DC credentials are **ephemeral** (never stored in the credential store)
- `[[CollectFromCredentialStore]]` is not implemented (`[[discovery]]` is `"remote"`)
- `[[Store]]` delegates to the default implementation, which throws `NotSupportedError` (credentials are never persisted)
- The construction algorithm never sets `[[origin]]` on the returned object

The actual origin-binding for DC happens at the **protocol layer** (wallet binds response to the requesting origin) and via Permissions Policy, transient activation, and user consent.

This aligns with `PublicKeyCredential` (WebAuthn), which also does not declare itself "origin bound" for similar reasons.

See also: w3c/webappsec-credential-management#295 (making `[[origin]]` universal but nullable on `Credential`).

The following tasks have been completed:

- [ ] Modified Web platform tests (N/A - no behavioral change)

Implementation commitment:

- [ ] WebKit (N/A - no behavioral change)
- [ ] Chromium (N/A - no behavioral change)
- [ ] Gecko (N/A - no behavioral change)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/509.html" title="Last updated on May 12, 2026, 10:18 PM UTC (2cbc3ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/509/8dc4712...2cbc3ab.html" title="Last updated on May 12, 2026, 10:18 PM UTC (2cbc3ab)">Diff</a>