### PR TITLE
Replace mediation "MUST NOT throw" prose with [[implicitMediation]] slot

### DIFF
--- a/index.html
+++ b/index.html
@@ -1437,19 +1437,14 @@
     </p>
     <p>
       The {{DigitalCredential}} interface mandates [=user mediation=] for all
-      operations to ensure user control and consent.
-    </p>
-    <p>
-      To simplify the developer experience of {{CredentialsContainer/get()}}
-      calls involving a {{DigitalCredential}}, [=user agents=] MUST NOT throw
-      an error if the {{CredentialRequestOptions/mediation}} member is absent
-      or has a value other than {{CredentialMediationRequirement/"required"}}.
-      Similarly, in {{CredentialsContainer/create()}} calls involving a
-      {{DigitalCredential}}, [=user agents=] MUST NOT throw an error if the
-      {{CredentialCreationOptions/mediation}} member is absent or has a value
-      other than {{CredentialMediationRequirement/"required"}}. This makes
-      {{CredentialMediationRequirement/"required"}} mediation an implicit and
-      non-overridable behavior of the API.
+      operations to ensure user control and consent. The
+      {{DigitalCredential}} [=interface object=] has an internal slot named
+      <dfn data-dfn-for="DigitalCredential">[[\implicitMediation]]</dfn> whose
+      value is {{CredentialMediationRequirement/"required"}}. This means the
+      credential type always behaves as if
+      {{CredentialMediationRequirement/"required"}} was passed, regardless of
+      the actual value of the
+      {{CredentialRequestOptions/mediation}} member.
     </p>
     <pre class="idl">
     typedef (DigitalCredentialPresentationProtocol or DigitalCredentialIssuanceProtocol) DigitalCredentialProtocol;

--- a/index.html
+++ b/index.html
@@ -1443,11 +1443,12 @@
     <p>
       The {{DigitalCredential}} interface mandates [=user mediation=] for all
       operations to ensure user control and consent. The {{DigitalCredential}}
-      [=interface object=] sets the {{Credential\[[implicitMediation]]}} to
-      {{CredentialMediationRequirement/"required"}}. This means the credential
-      type always behaves as if {{CredentialMediationRequirement/"required"}}
-      was passed, regardless of the actual value of the
-      {{CredentialRequestOptions/mediation}} member.
+      [=interface object=] sets the {{Credential/[[implicitMediation]]}}
+      internal slot to {{CredentialMediationRequirement/"required"}}. This
+      means the credential type always behaves as if
+      {{CredentialMediationRequirement/"required"}} was passed, regardless of
+      the actual value of the {{CredentialRequestOptions/mediation}} and
+      {{CredentialCreationOptions/mediation}} members.
     </p>
     <pre class="idl">
     typedef (DigitalCredentialPresentationProtocol or DigitalCredentialIssuanceProtocol) DigitalCredentialProtocol;

--- a/index.html
+++ b/index.html
@@ -1437,11 +1437,11 @@
     </p>
     <p>
       The {{DigitalCredential}} interface mandates [=user mediation=] for all
-      operations to ensure user control and consent. The {{DigitalCredential}} [=interface object=]  
-      sets the {{Credential\[[implicitMediation]]}} to {{CredentialMediationRequirement/"required"}}. 
-      This means the credential type always behaves as if
-      {{CredentialMediationRequirement/"required"}} was passed, regardless of
-      the actual value of the
+      operations to ensure user control and consent. The {{DigitalCredential}}
+      [=interface object=] sets the {{Credential\[[implicitMediation]]}} to
+      {{CredentialMediationRequirement/"required"}}. This means the credential
+      type always behaves as if {{CredentialMediationRequirement/"required"}}
+      was passed, regardless of the actual value of the
       {{CredentialRequestOptions/mediation}} member.
     </p>
     <pre class="idl">

--- a/index.html
+++ b/index.html
@@ -1437,11 +1437,9 @@
     </p>
     <p>
       The {{DigitalCredential}} interface mandates [=user mediation=] for all
-      operations to ensure user control and consent. The
-      {{DigitalCredential}} [=interface object=] has an internal slot named
-      <dfn data-dfn-for="DigitalCredential">[[\implicitMediation]]</dfn> whose
-      value is {{CredentialMediationRequirement/"required"}}. This means the
-      credential type always behaves as if
+      operations to ensure user control and consent. The {{DigitalCredential}} [=interface object=]  
+      sets the {{Credential\[[implicitMediation]]}} to {{CredentialMediationRequirement/"required"}}. 
+      This means the credential type always behaves as if
       {{CredentialMediationRequirement/"required"}} was passed, regardless of
       the actual value of the
       {{CredentialRequestOptions/mediation}} member.

--- a/index.html
+++ b/index.html
@@ -1484,19 +1484,13 @@
     </p>
     <p>
       The {{DigitalCredential}} interface mandates [=user mediation=] for all
-      operations to ensure user control and consent.
-    </p>
-    <p>
-      To simplify the developer experience of {{CredentialsContainer/get()}}
-      calls involving a {{DigitalCredential}}, [=user agents=] MUST NOT throw
-      an error if the {{CredentialRequestOptions/mediation}} member is absent
-      or has a value other than {{CredentialMediationRequirement/"required"}}.
-      Similarly, in {{CredentialsContainer/create()}} calls involving a
-      {{DigitalCredential}}, [=user agents=] MUST NOT throw an error if the
-      {{CredentialCreationOptions/mediation}} member is absent or has a value
-      other than {{CredentialMediationRequirement/"required"}}. This makes
-      {{CredentialMediationRequirement/"required"}} mediation an implicit and
-      non-overridable behavior of the [[[#DC-API|API]]].
+      operations to ensure user control and consent. The {{DigitalCredential}}
+      [=interface object=] sets the {{Credential/[[implicitMediation]]}}
+      internal slot to {{CredentialMediationRequirement/"required"}}. This
+      means the credential type always behaves as if
+      {{CredentialMediationRequirement/"required"}} was passed, regardless of
+      the actual value of the {{CredentialRequestOptions/mediation}} and
+      {{CredentialCreationOptions/mediation}} members.
     </p>
     <pre class="idl">
     typedef (DigitalCredentialPresentationProtocol or DigitalCredentialIssuanceProtocol) DigitalCredentialProtocol;


### PR DESCRIPTION
Closes #510

## Summary

Replaces the paragraph that said user agents "MUST NOT throw an error if the mediation member has a value other than required" with a proper `[[implicitMediation]]` internal slot declaration set to `"required"`.

## Why

The previous prose contradicted the upstream Credential Management spec's step 9, which throws TypeError for `mediation: "conditional"` with types that don't support it. That step fires before this spec's `[[DiscoverFromExternalSource]]` is called, making the "MUST NOT throw" instruction unreachable spec fiction.

WebKit's implementation already ignores mediation for digital credentials (no TypeError). This change aligns the spec with both the implementation and the upstream algorithm.

## Landing order

1. **w3c/webappsec-credential-management#298** lands first (adds `[[implicitMediation]]` slot and modifies step 9)
2. **This PR** lands second (declares the slot value for DigitalCredential)

## Related

- w3c/webappsec-credential-management#297 (Cred Man issue)
- w3c/webappsec-credential-management#298 (Cred Man PR — must land first)
- web-platform-tests/wpt#59087 (WPT test — should be updated after both land)

The following tasks have been completed:

- [ ] Modified Web platform tests (pending: depends on Cred Man PR landing first)

Implementation commitment:

- [ ] WebKit (already behaves this way — no code change needed)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/511.html" title="Last updated on Jun 26, 2026, 10:29 PM UTC (b63ddaf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/511/1b5612a...b63ddaf.html" title="Last updated on Jun 26, 2026, 10:29 PM UTC (b63ddaf)">Diff</a>