### PR TITLE
editorial: Fix WebDriver session links in Automated Testing section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2888,11 +2888,10 @@
         <li>If |action| is `"clear"`:
           <ol>
             <li>If |context| is not `null`, remove the entry for |context| from
-            the WebDriver [=session=]'s [=active virtual wallet
-            behavior=].
+            the WebDriver [=session=]'s [=active virtual wallet behavior=].
             </li>
-            <li>Else, set the WebDriver [=session=]'s [=active virtual
-            wallet behavior=] to `null`.
+            <li>Else, set the WebDriver [=session=]'s [=active virtual wallet
+            behavior=] to `null`.
             </li>
           </ol>
         </li>
@@ -2901,12 +2900,12 @@
             <li>Let |behavior| be a tuple of (|action|, |protocol|,
             |response|).
             </li>
-            <li>If |context| is not `null`, set the WebDriver
-            [=session=]'s <dfn>active virtual wallet behavior</dfn> for
-            the browsing context ID |context| to |behavior|.
+            <li>If |context| is not `null`, set the WebDriver [=session=]'s
+            <dfn>active virtual wallet behavior</dfn> for the browsing context
+            ID |context| to |behavior|.
             </li>
-            <li>Else, set the WebDriver [=session=]'s default [=active
-            virtual wallet behavior=] to |behavior|.
+            <li>Else, set the WebDriver [=session=]'s default [=active virtual
+            wallet behavior=] to |behavior|.
             </li>
           </ol>
         </li>
@@ -2925,8 +2924,8 @@
         </li>
         <li>Let |context ID| be the ID of |global|'s [=browsing context=].
         </li>
-        <li>Let |behavior| be the current WebDriver [=session=]'s
-        [=active virtual wallet behavior=] for |context ID|.
+        <li>Let |behavior| be the current WebDriver [=session=]'s [=active
+        virtual wallet behavior=] for |context ID|.
         </li>
         <li>If |behavior| is `null`, set |behavior| to the current WebDriver
         [=session=]'s default [=active virtual wallet behavior=].

--- a/index.html
+++ b/index.html
@@ -2888,10 +2888,10 @@
         <li>If |action| is `"clear"`:
           <ol>
             <li>If |context| is not `null`, remove the entry for |context| from
-            the WebDriver [=modules/session=]'s [=active virtual wallet
+            the WebDriver [=session=]'s [=active virtual wallet
             behavior=].
             </li>
-            <li>Else, set the WebDriver [=modules/session=]'s [=active virtual
+            <li>Else, set the WebDriver [=session=]'s [=active virtual
             wallet behavior=] to `null`.
             </li>
           </ol>
@@ -2902,10 +2902,10 @@
             |response|).
             </li>
             <li>If |context| is not `null`, set the WebDriver
-            [=modules/session=]'s <dfn>active virtual wallet behavior</dfn> for
+            [=session=]'s <dfn>active virtual wallet behavior</dfn> for
             the browsing context ID |context| to |behavior|.
             </li>
-            <li>Else, set the WebDriver [=modules/session=]'s default [=active
+            <li>Else, set the WebDriver [=session=]'s default [=active
             virtual wallet behavior=] to |behavior|.
             </li>
           </ol>
@@ -2925,11 +2925,11 @@
         </li>
         <li>Let |context ID| be the ID of |global|'s [=browsing context=].
         </li>
-        <li>Let |behavior| be the current WebDriver [=modules/session=]'s
+        <li>Let |behavior| be the current WebDriver [=session=]'s
         [=active virtual wallet behavior=] for |context ID|.
         </li>
         <li>If |behavior| is `null`, set |behavior| to the current WebDriver
-        [=modules/session=]'s default [=active virtual wallet behavior=].
+        [=session=]'s default [=active virtual wallet behavior=].
         </li>
         <li>If |behavior| is `null`, return `false`.
         </li>


### PR DESCRIPTION
Links to "WebDriver session" in the "Automated Testing" section were incorrectly resolving to the WebDriver BiDi session module (https://www.w3.org/TR/webdriver-bidi/#modules-session) instead of referring to the session concept in the context of the WebDriver specification.

This PR is fixing that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/514.html" title="Last updated on May 12, 2026, 1:43 PM UTC (7f0e488)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/514/90e10eb...7f0e488.html" title="Last updated on May 12, 2026, 1:43 PM UTC (7f0e488)">Diff</a>