### PR TITLE
editorial: Tweak cross-origin example

### DIFF
--- a/index.html
+++ b/index.html
@@ -380,7 +380,7 @@
       </p>
       <pre class="example html" title=
       "Requesting a digital credential across origins">
-        &lt;iframe src="https://wallet-provider.example.com"
+        &lt;iframe src="https://verifier-service.example.com"
                 allow="digital-credentials-get"&gt;
         &lt;/iframe&gt;
       </pre>


### PR DESCRIPTION
Very minor. The URL in the cross-origin example made it a bit confusing (referencing a "wallet provider"). Switched to a more realistic example: a verifier service.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/517.html" title="Last updated on May 14, 2026, 8:51 AM UTC (a256a96)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/517/b618614...a256a96.html" title="Last updated on May 14, 2026, 8:51 AM UTC (a256a96)">Diff</a>