### PR TITLE
editorial: extract "Convert request protocol" as standalone algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -690,6 +690,54 @@
         </tr>
       </tbody>
     </table><!--
+    // MARK: Convert request protocol
+    -->
+    <h3>
+      Convert request protocol
+    </h3>
+    <p>
+      To <dfn>convert request protocol</dfn> given a
+      {{DigitalCredentialGetRequest}} or {{DigitalCredentialCreateRequest}}
+      |request|:
+    </p>
+    <ol class="algorithm">
+      <li>If |request| is:
+        <dl class="switch">
+          <dt>
+            A {{DigitalCredentialGetRequest}}:
+          </dt>
+          <dd>
+            <ol>
+              <li>Let |protocolString| be |request|'s
+              {{DigitalCredentialGetRequest/protocol}}.
+              </li>
+              <li>If |protocolString| does not equal any [=enumeration value=]
+              in {{DigitalCredentialPresentationProtocol}}, return failure.
+              </li>
+              <li>Return the {{DigitalCredentialPresentationProtocol}}
+              [=enumeration value=] whose value is |protocolString|.
+              </li>
+            </ol>
+          </dd>
+          <dt>
+            A {{DigitalCredentialCreateRequest}}:
+          </dt>
+          <dd>
+            <ol>
+              <li>Let |protocolString| be |request|'s
+              {{DigitalCredentialCreateRequest/protocol}}.
+              </li>
+              <li>If |protocolString| does not equal any [=enumeration value=]
+              in {{DigitalCredentialIssuanceProtocol}}, return failure.
+              </li>
+              <li>Return the {{DigitalCredentialIssuanceProtocol}}
+              [=enumeration value=] whose value is |protocolString|.
+              </li>
+            </ol>
+          </dd>
+        </dl>
+      </li>
+    </ol><!--
     // MARK: Credential Request Coordinator
     -->
     <h2>
@@ -907,19 +955,13 @@
       </li>
       <li>[=List/For each=] |request| of |requests|:
         <ol>
-          <li>Let |protocol| be |request|'s
-          {{DigitalCredentialGetRequest/protocol}}, if |request| is a
-          {{DigitalCredentialGetRequest}}, or |request|'s
-          {{DigitalCredentialCreateRequest/protocol}}, if |request| is a
-          {{DigitalCredentialCreateRequest}}.
-          </li>
-          <li>If |request| is a {{DigitalCredentialGetRequest}} and |protocol|
-          does not equal any [=enumeration value=] in
-          {{DigitalCredentialPresentationProtocol}}, [=iteration/continue=].
-          </li>
-          <li>If |request| is a {{DigitalCredentialCreateRequest}} and
-          |protocol| does not equal any [=enumeration value=] in
-          {{DigitalCredentialIssuanceProtocol}}, [=iteration/continue=].
+          <li>[=Convert request protocol=] given |request|:
+            <ol>
+              <li>If conversion results in failure, [=iteration/continue=].
+              </li>
+              <li>Otherwise, let |protocol| be the result of the conversion.
+              </li>
+            </ol>
           </li>
           <li>If [=user agent allows protocol=] given |protocol| returns
           `false`, [=iteration/continue=].

--- a/index.html
+++ b/index.html
@@ -954,13 +954,10 @@
       </li>
       <li>[=List/For each=] |request| of |requests|:
         <ol>
-          <li>[=Convert request protocol=] given |request|:
-            <ol>
-              <li>If conversion results in failure, [=iteration/continue=].
-              </li>
-              <li>Otherwise, let |protocol| be the result of the conversion.
-              </li>
-            </ol>
+          <li>Let |protocol| be the result of running [=convert request protocol=]
+          given |request|.
+          </li>
+          <li>If |protocol| is failure, [=iteration/continue=].
           </li>
           <li>If [=user agent allows protocol=] given |protocol| returns
           `false`, [=iteration/continue=].


### PR DESCRIPTION
Follows up on #521, which narrowed scope by removing this refactor to unblock the normative work.

This PR restores the standalone `Convert request protocol` algorithm in the Protocols section and updates `Validate credential requests` to call it, replacing the previously inlined steps.

No normative change.

## Changes

- Adds `<dfn>convert request protocol</dfn>` algorithm to the Protocols section
- Replaces 3 inlined protocol-extraction/validation steps in `Validate credential requests` with a compact `[=Convert request protocol=]` call


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/522.html" title="Last updated on Jun 15, 2026, 1:58 PM UTC (c8265ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/522/5ab9d18...c8265ad.html" title="Last updated on Jun 15, 2026, 1:58 PM UTC (c8265ad)">Diff</a>