### PR TITLE
Privacy Considerations: state the user agent's baseline linkability assumption

### DIFF
--- a/index.html
+++ b/index.html
@@ -1887,7 +1887,7 @@
           contexts (verifier-verifier and verifier-issuer linkability). Whether
           a presentation is linkable is determined by the [=digital
           credential/presentation protocol=], credential format, and credential
-          [=claims=], so mitigation occurs at the protocol and format layer,
+          [=claims=], so mitigation occurs at the protocol and format layers,
           outside the scope of this API. This threat remains relevant here
           because the [=user agent=] cannot observe the contents of an opaque
           credential response and so adopts a conservative posture that assumes

--- a/index.html
+++ b/index.html
@@ -1887,13 +1887,11 @@
           contexts (verifier-verifier and verifier-issuer linkability). Whether
           a presentation is linkable is determined by the [=digital
           credential/presentation protocol=], credential format, and credential
-          claims, so mitigation occurs at the protocol and format layer,
-          outside of this API. It remains relevant here because the [=user
-          agent=] cannot observe credential response contents and so cannot
-          confirm that any unlinkability property holds; the API's role is
-          limited to the [=user agent=] adopting a conservative posture that
-          assumes a presentation may be linkable. See
-          [[[#unlinkable-presentations]]].
+          [=claims=], so mitigation occurs at the protocol and format layer,
+          outside the scope of this API. This threat remains relevant here
+          because the [=user agent=] cannot observe the contents of an opaque
+          credential response and so adopts a conservative posture that assumes
+          a presentation may be linkable. See [[[#unlinkable-presentations]]].
         </dd>
       </dl>
       <h3>
@@ -2161,24 +2159,22 @@
         <p>
           Through the Digital Credentials API, the [=user agent=] can help
           [=verifiers=] and [=credential managers=] exchange unlinkable claims,
-          but, because of response encryption, it cannot guarantee that no
-          linkable information is passed between [=verifiers=] and [=credential
-          managers=]. It is recommended that [=user agents=] account for this
-          fact in their user permission experience.
-        </p>
-        <p>
-          This API does not by itself make a [=digital
-          credential/presentation|presentation=] unlinkable; where
+          but it does not by itself make a [=digital
+          credential/presentation|presentation=] unlinkable: where
           unlinkability is achieved, it is a property of the credential format,
           [=digital credential/presentation protocol=], and credential claims
           in use, and, for verifier-verifier linkability, of the [=holder=] and
           [=issuer=] (as described above). Because the [=user agent=] cannot
           observe the contents of an opaque credential response, it cannot
-          confirm that any such unlinkability property holds. The [=user
-          agent=] therefore assumes a presentation may be linkable, both across
-          [=verifiers=] (verifier-verifier linkability) and back to the
-          [=issuer=] (verifier-issuer linkability), when shaping its permission
-          experience.
+          confirm that any such unlinkability property holds, and therefore
+          assumes a presentation may be linkable, both across [=verifiers=]
+          (verifier-verifier linkability) and back to the [=issuer=]
+          (verifier-issuer linkability). It is recommended that [=user agents=]
+          account for this in their permission experience, for example by
+          indicating whether presenting the requested information may enable
+          tracking (see [[[#user-permission-and-transparency]]]), or by
+          applying a higher level of friction and clear messaging that
+          highlights the risk.
         </p>
         <p class="issue" data-number="279">
           Which level of unlinkability is the goal for this API? Can we

--- a/index.html
+++ b/index.html
@@ -1886,13 +1886,14 @@
           credential/presentation|presentations=] to track a user across
           contexts (verifier-verifier and verifier-issuer linkability). Whether
           a presentation is linkable is determined by the [=digital
-          credential/presentation protocol=] and credential format, so
-          mitigation occurs at the protocol and format layer, outside of this
-          API. It remains relevant here because the [=user agent=] cannot
-          observe credential response contents and so cannot confirm that any
-          unlinkability property holds; the API's role is limited to the [=user
-          agent=] adopting a conservative posture that assumes a presentation
-          may be linkable. See [[[#unlinkable-presentations]]].
+          credential/presentation protocol=], credential format, and credential
+          claims, so mitigation occurs at the protocol and format layer,
+          outside of this API. It remains relevant here because the [=user
+          agent=] cannot observe credential response contents and so cannot
+          confirm that any unlinkability property holds; the API's role is
+          limited to the [=user agent=] adopting a conservative posture that
+          assumes a presentation may be linkable. See
+          [[[#unlinkable-presentations]]].
         </dd>
       </dl>
       <h3>
@@ -2168,15 +2169,15 @@
         <p>
           This API does not by itself make a [=digital
           credential/presentation|presentation=] unlinkable; where
-          unlinkability is achieved, it is a property of the credential format
-          and [=digital credential/presentation protocol=] in use, and, for
-          verifier-verifier linkability, of the [=holder=] and [=issuer=] (as
-          described above). Because the [=user agent=] cannot observe the
-          contents of an opaque credential response, it cannot confirm that any
-          such unlinkability property holds. The [=user agent=] therefore
-          assumes a presentation may be linkable, both across [=verifiers=]
-          (verifier-verifier linkability) and back to the [=issuer=]
-          (verifier-issuer linkability), when shaping its permission
+          unlinkability is achieved, it is a property of the credential format,
+          [=digital credential/presentation protocol=], and credential claims
+          in use, and, for verifier-verifier linkability, of the [=holder=] and
+          [=issuer=] (as described above). Because the [=user agent=] cannot
+          observe the contents of an opaque credential response, it cannot
+          confirm that any such unlinkability property holds. The [=user
+          agent=] therefore assumes a presentation may be linkable, both across
+          [=verifiers=] (verifier-verifier linkability) and back to the
+          [=issuer=] (verifier-issuer linkability), when shaping its permission
           experience.
         </p>
         <p class="issue" data-number="279">

--- a/index.html
+++ b/index.html
@@ -2134,7 +2134,7 @@
         </h5>
         <p>
           [[[credential-considerations#unlinkable-presentations|Unlinkability]]]
-          is a property that ensures that, if a user presents attributes from a
+          is a property that ensures that, if a user presents [=claims=] from a
           credential multiple times, [=verifiers=] cannot link these separate
           presentations to conclude they concern the same user
           (verifier-verifier linkability), or that [=verifiers=] cannot collude
@@ -2153,18 +2153,18 @@
           requested to limit linkability wherever possible.
         </p>
         <p>
-          Note that unlinkability is exclusively a consideration for attributes
+          Note that unlinkability is exclusively a consideration for claims
           that cannot be linked to a specific user identity. Inherently
-          linkable attributes such as names, driver's license numbers, or phone
+          linkable properties such as names, driver's license numbers, or phone
           numbers do not benefit from unlinkability.
         </p>
         <p>
           Through the Digital Credentials API, the [=user agent=] can help
-          [=verifiers=] and [=credential managers=] exchange unlinkable
-          attributes, but, because of response encryption, it cannot guarantee
-          that no linkable information is passed between [=verifiers=] and
-          [=credential managers=]. It is recommended that [=user agents=]
-          account for this fact in their user permission experience.
+          [=verifiers=] and [=credential managers=] exchange unlinkable claims,
+          but, because of response encryption, it cannot guarantee that no
+          linkable information is passed between [=verifiers=] and [=credential
+          managers=]. It is recommended that [=user agents=] account for this
+          fact in their user permission experience.
         </p>
         <p>
           This API does not by itself make a [=digital

--- a/index.html
+++ b/index.html
@@ -1876,10 +1876,25 @@
         end-to-end security of credential presentation and issuance. The
         following defines the [=out-of-scope threats=] for this specification:
       </p>
-      <ul>
-        <li>To be written...
-        </li>
-      </ul>
+      <dl>
+        <dt>
+          <dfn>Presentation Linkability</dfn>
+        </dt>
+        <dd>
+          A [=verifier=], alone or colluding with other [=verifiers=] or with
+          an [=issuer=], correlates multiple [=digital
+          credential/presentation|presentations=] to track a user across
+          contexts (verifier-verifier and verifier-issuer linkability). Whether
+          a presentation is linkable is determined by the [=digital
+          credential/presentation protocol=] and credential format, so
+          mitigation occurs at the protocol and format layer, outside of this
+          API. It remains relevant here because the [=user agent=] cannot
+          observe credential response contents and so cannot confirm that any
+          unlinkability property holds; the API's role is limited to the [=user
+          agent=] adopting a conservative posture that assumes a presentation
+          may be linkable. See [[[#unlinkable-presentations]]].
+        </dd>
+      </dl>
       <h3>
         Mitigations
       </h3>
@@ -2113,7 +2128,7 @@
           selective disclosure by allowing the [=verifier=] to specify the
           exact claims needed.
         </p>
-        <h5>
+        <h5 id="unlinkable-presentations">
           Unlinkable presentations
         </h5>
         <p>
@@ -2149,6 +2164,20 @@
           that no linkable information is passed between [=verifiers=] and
           [=credential managers=]. It is recommended that [=user agents=]
           account for this fact in their user permission experience.
+        </p>
+        <p>
+          This API does not by itself make a [=digital
+          credential/presentation|presentation=] unlinkable; where
+          unlinkability is achieved, it is a property of the credential format
+          and [=digital credential/presentation protocol=] in use, and, for
+          verifier-verifier linkability, of the [=holder=] and [=issuer=] (as
+          described above). Because the [=user agent=] cannot observe the
+          contents of an opaque credential response, it cannot confirm that any
+          such unlinkability property holds. The [=user agent=] therefore
+          assumes a presentation may be linkable, both across [=verifiers=]
+          (verifier-verifier linkability) and back to the [=issuer=]
+          (verifier-issuer linkability), when shaping its permission
+          experience.
         </p>
         <p class="issue" data-number="279">
           Which level of unlinkability is the goal for this API? Can we


### PR DESCRIPTION
Issue #122 asks whether the user agent should assume credential requests are linkable. Two gaps stand in the way of answering it: Privacy Considerations discusses unlinkability without ever stating that baseline assumption, and the Threat Model's Out of Scope Threats list is still an empty "To be written..." placeholder.

This fills both: a baseline-assumption paragraph in Unlinkable presentations, and a matching Presentation Linkability entry in the Out of Scope Threats list. Informative prose only, no normative or API change. It does not decide how much unlinkability the API should mandate, which stays in #279.

Addresses #122.

The following tasks have been completed:

- [ ] Modified Web platform tests (link) — n/a, informative prose

Implementation commitment:

- [ ] WebKit (link to issue) — n/a, no API surface change
- [ ] Chromium (link to issue) — n/a
- [ ] Gecko (link to issue) — n/a

Documentation and checks

- [x] Affects privacy
- [x] Affects security
- [ ] Pinged MDN — n/a
- [ ] Updated Explainer — n/a
- [ ] Updated digitalcredentials.dev — n/a


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/528.html" title="Last updated on Jun 18, 2026, 8:09 PM UTC (9e5e7d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/528/8ff9184...9e5e7d3.html" title="Last updated on Jun 18, 2026, 8:09 PM UTC (9e5e7d3)">Diff</a>