### PR TITLE
Update API to return an array of DigitalCredential instances

### DIFF
--- a/index.html
+++ b/index.html
@@ -710,7 +710,7 @@
       agent initializes as `null`. Through this {{Promise}}, the
       [=coordinator=] reflects the state of the asynchronous [=digital
       credential/credential request=] workflow to script and either
-      [=resolves=] with a [=digital credential/credential response=] when the
+      [=resolves=] with a [=sequence=] of {{DigitalCredential}} instances when the
       interaction completes successfully, or [=rejects=] when processing fails,
       when the user cancels the request via the UI, or when script aborts the
       operation via an {{AbortSignal}}.
@@ -1151,22 +1151,16 @@
               </li>
             </ol>
           </li>
-          <li>If a [=digital credential=] was selected by the user:
+          <li>If one or more [=digital credentials=] were selected by the user:
             <ol>
-              <li>Let |protocol| be the [=digital credential/protocol
-              identifier=] returned by the [=digital credential chooser=] for
-              this exchange.
+              <li>Let |responses| be a [=sequence=] of items returned by the [=digital credential chooser=], where each item consists of a [=digital credential/protocol identifier=] |protocol| and a [=string=] |responseData| representing a [=digital credential/presentation response=] or [=digital credential/issuance response=] returned by the [=holder=].
                 <p class="note" title="Protocol is determined by the platform">
                   The [=digital credential chooser=] or underlying platform
-                  determines which item in |validatedRequests| to forward to a
+                  determines which items in |validatedRequests| to forward to a
                   [=holder=] and returns the [=digital credential/protocol
-                  identifier=] for that exchange. The user agent does not
-                  necessarily know which specific item was selected.
+                  identifier=] for each exchange. The user agent does not
+                  necessarily know which specific items were selected.
                 </p>
-              </li>
-              <li>Let |responseData| be a [=string=] [=digital
-              credential/presentation response=] or [=string=] [=digital
-              credential/issuance response=] returned by the [=holder=].
                 <aside class="note" title="Why the response is a string">
                   The response is a string because the user agent is
                   responsible for parsing it into a JavaScript object in the
@@ -1182,9 +1176,6 @@
                   <li>If the [=credential request coordinator=]'s [=credential
                   request coordinator/active promise=] is not |promise|, then
                   return.
-                  </li>
-                  <li>Let |parsedResponseDataOrError| be the result of [=parse
-                  a JSON string to a JavaScript value=] given |responseData|.
                   </li>
                   <li>Let |abortSignal| be the [=credential request
                   coordinator=]'s [=credential request coordinator/abort
@@ -1204,31 +1195,48 @@
                   <li>Set the [=credential request coordinator=]'s [=credential
                   request coordinator/abort algorithm=] to `null`.
                   </li>
-                  <li>If |parsedResponseDataOrError| is an [=exception=]:
+                  <li>Let |credentials| be a new [=list=].
+                  </li>
+                  <li>For each |response| in |responses|:
                     <ol>
-                      <li>[=Reject=] |promise| with
-                      |parsedResponseDataOrError|.
+                      <li>Let |parsedResponseDataOrError| be the result of [=parse
+                      a JSON string to a JavaScript value=] given |response|'s |responseData|.
+                      </li>
+                      <li>If |parsedResponseDataOrError| is an [=exception=]:
+                        <ol>
+                          <li>[=Reject=] |promise| with
+                          |parsedResponseDataOrError|.
+                          </li>
+                          <li>Return.
+                          </li>
+                        </ol>
+                      </li>
+                      <li>Otherwise, if |parsedResponseDataOrError| is not an
+                      [=object=]:
+                        <ol>
+                          <li>[=Reject=] |promise| with a newly created
+                          {{TypeError}}.
+                          </li>
+                          <li>Return.
+                          </li>
+                        </ol>
+                      </li>
+                      <li>Otherwise:
+                        <ol>
+                          <li>Let |credential| be a newly created
+                          {{DigitalCredential}} instance with its
+                          {{DigitalCredential/data}} initialized to
+                          |parsedResponseDataOrError| and its
+                          {{DigitalCredential/protocol}} initialized to |response|'s |protocol|.
+                          </li>
+                          <li>[=list/Append=] |credential| to |credentials|.
+                          </li>
+                        </ol>
                       </li>
                     </ol>
                   </li>
-                  <li>Otherwise, if |parsedResponseDataOrError| is not an
-                  [=object=]:
-                    <ol>
-                      <li>[=Reject=] |promise| with a newly created
-                      {{TypeError}}.
-                      </li>
-                    </ol>
+                  <li>[=Resolve=] |promise| with |credentials|.
                   </li>
-                  <li>Otherwise:
-                    <ol>
-                      <li>Let |credential| be a newly created
-                      {{DigitalCredential}} instance with its
-                      {{DigitalCredential/data}} initialized to
-                      |parsedResponseDataOrError| and its
-                      {{DigitalCredential/protocol}} initialized to |protocol|.
-                      </li>
-                      <li>[=Resolve=] |promise| with |credential|.
-                      </li>
                     </ol>
                   </li>
                   <li>Set the [=credential request coordinator=]'s [=credential
@@ -2962,7 +2970,7 @@
             object|.
             </li>
             <li>[=Queue a global task=] on the [=DOM manipulation task source=]
-            given |global| to [=resolve=] |promise| with |credential|.
+            given |global| to [=resolve=] |promise| with a [=list=] containing |credential|.
             </li>
             <li>Return `true`.
             </li>


### PR DESCRIPTION
Closes #222 

This PR updates the 'discover from external source' algorithm and mock mechanics to expect multiple responses from the credential chooser/platform, and resolves the credential request Promise with a sequence of DigitalCredential instances rather than a single instance.

Depends on: w3c/webappsec-credential-management#301 (Upstream Web IDL changes allowing navigator.credentials.get() to return a sequence of credentials).

The following tasks have been completed:

- [ ] Modified Web platform tests (link)

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/531.html" title="Last updated on Jun 15, 2026, 2:29 PM UTC (4d822a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/531/272891c...4d822a0.html" title="Last updated on Jun 15, 2026, 2:29 PM UTC (4d822a0)">Diff</a>