### PR TITLE
Security: Expand Threat Model and mitigate malicious payloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -1893,12 +1893,14 @@
         information.
       </p>
       <p>
-        To mitigate the risk of <a href="#dfn-malicious-payloads-to-the-underlying-platform">malicious payloads to the underlying platform</a>, [=user agents=] MUST pass the request
-        parameters to the [=credential manager=] using safe serialization
-        formats (such as JSON or structured cloning) without executing them.
-        The underlying platform and [=credential managers=] are responsible
-        for robustly parsing and validating these protocol-specific payloads
-        before acting on them.
+        To mitigate the risk of <a
+        href="#dfn-malicious-payloads-to-the-underlying-platform">malicious
+        payloads to the underlying platform</a>, [=user agents=] MUST pass
+        the request parameters to the [=credential manager=] using safe
+        serialization formats (such as JSON or structured cloning) without
+        executing them. The underlying platform and [=credential managers=]
+        are responsible for robustly parsing and validating these
+        protocol-specific payloads before acting on them.
       </p>
       <p>
         The Digital Credentials API reduces [=API flooding=] through two

--- a/index.html
+++ b/index.html
@@ -1869,11 +1869,11 @@
           <dfn>Protocol and Format Vulnerabilities</dfn>
         </dt>
         <dd>
-          Weaknesses in the specific [=digital credential/presentation protocol=]
-          or credential format being used (e.g., cryptographic flaws, lack of
-          replay protection) could allow attackers to intercept, forge, or
-          tamper with credentials in transit. Mitigation occurs at the protocol
-          and transport layers (e.g., TLS).
+          Weaknesses in the specific [=digital credential/presentation
+          protocol=] or credential format being used (e.g., cryptographic
+          flaws, lack of replay protection) could allow attackers to intercept,
+          forge, or tamper with credentials in transit. Mitigation occurs at
+          the protocol and transport layers (e.g., TLS).
         </dd>
       </dl>
       <h3>
@@ -1893,14 +1893,14 @@
         information.
       </p>
       <p>
-        To mitigate the risk of <a
-        href="#dfn-malicious-payloads-to-the-underlying-platform">malicious
-        payloads to the underlying platform</a>, [=user agents=] MUST pass
-        the request parameters to the [=credential manager=] using safe
-        serialization formats (such as JSON or structured cloning) without
-        executing them. The underlying platform and [=credential managers=]
-        are responsible for robustly parsing and validating these
-        protocol-specific payloads before acting on them.
+        To mitigate the risk of <a href=
+        "#dfn-malicious-payloads-to-the-underlying-platform">malicious payloads
+        to the underlying platform</a>, [=user agents=] MUST pass the request
+        parameters to the [=credential manager=] using safe serialization
+        formats (such as JSON or structured cloning) without executing them.
+        The underlying platform and [=credential managers=] are responsible for
+        robustly parsing and validating these protocol-specific payloads before
+        acting on them.
       </p>
       <p>
         The Digital Credentials API reduces [=API flooding=] through two

--- a/index.html
+++ b/index.html
@@ -1826,6 +1826,14 @@
           explicit permission from the embedding site, potentially enabling
           credential harvesting or unauthorized access to sensitive user data.
         </dd>
+        <dt>
+          <dfn>Malicious Payloads to the Underlying Platform</dfn>
+        </dt>
+        <dd>
+          A malicious website attempts to exploit vulnerabilities in the
+          underlying operating system or [=credential manager=] by passing
+          carefully crafted or malformed protocol requests through the API.
+        </dd>
       </dl>
       <h4>
         Out of Scope Threats
@@ -1837,10 +1845,37 @@
         end-to-end security of credential presentation and issuance. The
         following defines the [=out-of-scope threats=] for this specification:
       </p>
-      <ul>
-        <li>To be written...
-        </li>
-      </ul>
+      <dl>
+        <dt>
+          <dfn>OS or Device Compromise</dfn>
+        </dt>
+        <dd>
+          An attacker who gains control over the user's operating system or
+          device hardware could bypass [=user agent=] protections, extract
+          sensitive credential data directly from storage, or manipulate the
+          API calls. This threat must be addressed by OS platform security and
+          hardware-backed keystores.
+        </dd>
+        <dt>
+          <dfn>Malicious Credential Managers</dfn>
+        </dt>
+        <dd>
+          A user might install a [=credential manager=] that intentionally
+          leaks credentials, fails to securely encrypt them, or ignores user
+          consent. The API relies on the OS and the user's discretion to only
+          install and register trusted [=credential managers=].
+        </dd>
+        <dt>
+          <dfn>Protocol and Format Vulnerabilities</dfn>
+        </dt>
+        <dd>
+          Weaknesses in the specific [=digital credential/presentation protocol=]
+          or credential format being used (e.g., cryptographic flaws, lack of
+          replay protection) could allow attackers to intercept, forge, or
+          tamper with credentials in transit. Mitigation occurs at the protocol
+          and transport layers (e.g., TLS).
+        </dd>
+      </dl>
       <h3>
         Mitigations
       </h3>
@@ -1856,6 +1891,14 @@
         [[[secure-contexts#security-considerations|Security Considerations]]]
         section of the [[[secure-contexts]]] specification for more
         information.
+      </p>
+      <p>
+        To mitigate the risk of <a href="#dfn-malicious-payloads-to-the-underlying-platform">malicious payloads to the underlying platform</a>, [=user agents=] MUST pass the request
+        parameters to the [=credential manager=] using safe serialization
+        formats (such as JSON or structured cloning) without executing them.
+        The underlying platform and [=credential managers=] are responsible
+        for robustly parsing and validating these protocol-specific payloads
+        before acting on them.
       </p>
       <p>
         The Digital Credentials API reduces [=API flooding=] through two

--- a/index.html
+++ b/index.html
@@ -1889,7 +1889,7 @@
           An attacker who gains control over the user's operating system or
           device hardware could bypass [=user agent=] protections, extract
           sensitive credential data directly from storage, or manipulate the
-          API calls. This threat must be addressed by OS platform security and
+          API calls. This threat is addressed by OS platform security and
           hardware-backed keystores.
         </dd>
         <dt>
@@ -1928,14 +1928,14 @@
         [[[secure-contexts]]] specification for more information.
       </p>
       <p>
-        To mitigate the risk of <a href=
-        "#dfn-malicious-payloads-to-the-underlying-platform">malicious payloads
-        to the underlying platform</a>, [=user agents=] MUST pass the request
-        parameters to the [=credential manager=] using safe serialization
-        formats (such as JSON or structured cloning) without executing them.
+        To mitigate the risk of [=malicious payloads
+        to the underlying platform=], [=user agents=] pass the request
+        parameters to the [=credential manager=] using 
+        [=serialize a JavaScript value to a JSON string|JSON serialization=].
         The underlying platform and [=credential managers=] are responsible for
-        robustly parsing and validating these protocol-specific payloads before
-        acting on them.
+        [=validate credential requests|validating=] 
+        these protocol-specific payloads before 
+        [=initiate the credential request|acting=] on them.
       </p>
       <p>
         The Digital Credentials API reduces [=API flooding=] through two

--- a/index.html
+++ b/index.html
@@ -1893,8 +1893,8 @@
           leaks data, fails to securely encrypt credentials, or ignores user
           consent. While the API protects users prior to wallet selection
           through explicit user permission (see
-          [[[#user-permission-and-transparency]]]) and supports selective
-          disclosure, the API cannot govern the internal behavior of a
+          [[[#user-permission-and-transparency]]]), it cannot govern the internal
+          behavior of a
           [=credential manager=] once the user authorizes it to handle a
           request. Mitigating this risk relies on OS platform security, app
           store vetting, and legal/regulatory frameworks governing wallet

--- a/index.html
+++ b/index.html
@@ -1896,20 +1896,34 @@
           <dfn>Malicious Credential Managers</dfn>
         </dt>
         <dd>
-          A user might install a [=credential manager=] that intentionally
-          leaks credentials, fails to securely encrypt them, or ignores user
-          consent. The API relies on the OS and the user's discretion to only
-          install and register trusted [=credential managers=].
+          A user might install, or be coerced by institutional mandate or
+          essential services to use, a [=credential manager=] that intentionally
+          leaks data, fails to securely encrypt credentials, or ignores user
+          consent. While the API protects users prior to wallet selection
+          through explicit user permission (see
+          [[[#user-permission-and-transparency]]]) and supports selective
+          disclosure, the API cannot govern the internal behavior of a
+          [=credential manager=] once the user authorizes it to handle a
+          request. Mitigating this risk relies on OS platform security, app
+          store vetting, and legal/regulatory frameworks governing wallet
+          providers.
         </dd>
         <dt>
           <dfn>Protocol and Format Vulnerabilities</dfn>
         </dt>
         <dd>
           Weaknesses in the specific [=digital credential/presentation
-          protocol=] or credential format being used (e.g., cryptographic
-          flaws, lack of replay protection) could allow attackers to intercept,
-          forge, or tamper with credentials in transit. Mitigation occurs at
-          the protocol and transport layers (e.g., TLS).
+          protocol=], [=digital credential/issuance protocol=], or credential
+          format being used (e.g., cryptographic flaws, lack of replay
+          protection, or missing request authentication) could allow attackers to
+          intercept, forge, or tamper with credentials in transit. Mitigation
+          occurs primarily at the protocol, format, and transport layers (e.g.,
+          mandating response encryption, request signing, and TLS). While the API
+          does not define format-specific cryptography, it enforces baseline
+          security criteria on supported protocols (such as requiring
+          [[[#encrypting-credential-responses|response encryption]]] and
+          encouraging [[[#signing-presentation-requests|signed requests]]]) to
+          steer requests through the most secure path.
         </dd>
       </dl>
       <h3>
@@ -1928,14 +1942,13 @@
         [[[secure-contexts]]] specification for more information.
       </p>
       <p>
-        To mitigate the risk of [=malicious payloads
-        to the underlying platform=], [=user agents=] pass the request
-        parameters to the [=credential manager=] using 
-        [=serialize a JavaScript value to a JSON string|JSON serialization=].
-        The underlying platform and [=credential managers=] are responsible for
-        [=validate credential requests|validating=] 
-        these protocol-specific payloads before 
-        [=initiate the credential request|acting=] on them.
+        To mitigate the risk of [=malicious payloads to the underlying
+        platform=], [=user agents=] pass request parameters to the
+        [=credential manager=] using [=serialize a JavaScript value to a JSON
+        string|JSON serialization=] (see [=credential request
+        coordinator/validate credential requests=]). The underlying platform
+        and [=credential managers=] are responsible for robustly parsing and
+        validating these protocol-specific JSON payloads before acting on them.
       </p>
       <p>
         The Digital Credentials API reduces [=API flooding=] through two


### PR DESCRIPTION
Closes #???

Expands the Threat Model in the Security Considerations section to address gaps identified in the W3C Security Questionnaire:
- **Malicious Payloads to the Underlying Platform**: Added as an In-Scope Threat, along with a mitigation requiring User Agents to pass payloads using safe serialization to protect the OS/Wallet from parsing bugs.
- **Out of Scope Threats**: Formalizes OS/Device compromise, malicious credential managers, and protocol vulnerabilities.
Addresses parts of #233.

The following tasks have been completed:

- [ ] Modified Web platform tests (link)

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/533.html" title="Last updated on Aug 26, 2026, 1:07 PM UTC (dc8f639)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/533/2e9b687...dc8f639.html" title="Last updated on Aug 26, 2026, 1:07 PM UTC (dc8f639)">Diff</a>