### PR TITLE
Privacy: Define expectations for Private Browsing (Incognito) Mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -2727,6 +2727,27 @@
           improve the user permission experience as well.
         </p>
       </section>
+      <section>
+        <!--
+        // MARK: Private Browsing Mode
+        -->
+        <h3>
+          Private Browsing Mode
+        </h3>
+        <p>
+          When the [=user agent=] is operating in a private browsing mode (also
+          known as "incognito mode"), it is expected to prioritize user privacy
+          and prevent the accumulation of state that could link sessions.
+          Because [=digital credentials=] inherently contain identity and behavioral
+          history, [=user agents=] may choose to disable the Digital Credentials
+          API entirely in such modes. If supported, [=user agents=] are expected to ensure
+          that no trace of the credential request, presentation, or user choice
+          is left in the local browser state after the private session ends, and
+          are encouraged to warn users that presenting a credential may still
+          allow the [=verifier=] to uniquely identify them regardless of the
+          browsing mode.
+        </p>
+      </section>
     </section>
     <section>
       <!--


### PR DESCRIPTION
Closes #416 

Addresses #416 by adding a new "Private Browsing Mode" section to Privacy Considerations.
It states the expectation that User Agents prioritize user privacy by not persisting session state from the credential presentation process and optionally disabling the API if needed.

The following tasks have been completed:

- [ ] Modified Web platform tests (link)

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/534.html" title="Last updated on Jul 8, 2026, 10:15 PM UTC (a310273)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/534/1b5612a...a310273.html" title="Last updated on Jul 8, 2026, 10:15 PM UTC (a310273)">Diff</a>