### PR TITLE
Prevent opaque origins from interacting with the Digital Credentials API 

### DIFF
--- a/.cspell/misc.txt
+++ b/.cspell/misc.txt
@@ -10,3 +10,4 @@ fingerprinters
 birthdates
 reidentify
 multisigned
+sandboxed

--- a/index.html
+++ b/index.html
@@ -1648,6 +1648,9 @@
       <li>Let |signal| be |options|'s {{CredentialRequestOptions/signal}}, if
       present.
       </li>
+      <li>If |origin| is an [=opaque origin=], return [=a promise rejected
+      with=] a {{"NotAllowedError"}} {{DOMException}}.
+      </li>
       <li>Let |global| be [=this=]'s [=relevant global object=].
       </li>
       <li>Let |document| be |global|'s [=associated `Document`=].
@@ -1704,6 +1707,9 @@
       </li>
       <li>If |signal| is [=AbortSignal/aborted=], return [=a promise rejected
       with=] |signal|'s [=AbortSignal/abort reason=].
+      </li>
+      <li>If |origin| is an [=opaque origin=], return [=a promise rejected
+      with=] a {{"NotAllowedError"}} {{DOMException}}.
       </li>
       <li>Let |global| be [=this=]'s [=relevant global object=].
       </li>
@@ -1891,6 +1897,14 @@
         injected through the network). Please refer to the
         [[[secure-contexts#security-considerations]]] section of the
         [[[secure-contexts]]] specification for more information.
+      </p>
+      <p>
+        Additionally, the API is only available to documents with a non-opaque
+        origin. Calls to {{DigitalCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}}
+        and {{Credential/[[Create]](origin, options, sameOriginWithAncestors)}}
+        from [=opaque origins=] (such as `data:` URIs or sandboxed iframes) will
+        fail, reducing the risk of malicious extraction or spoofing from
+        untrusted environments.
       </p>
       <p>
         The Digital Credentials API reduces [=API flooding=] through two

--- a/index.html
+++ b/index.html
@@ -1649,7 +1649,7 @@
       present.
       </li>
       <li>If |origin| is an [=opaque origin=], return [=a promise rejected
-      with=] a {{"NotAllowedError"}} {{DOMException}}.
+      with=] a {{"SecurityError"}} {{DOMException}}.
       </li>
       <li>Let |global| be [=this=]'s [=relevant global object=].
       </li>

--- a/index.html
+++ b/index.html
@@ -1901,9 +1901,9 @@
       <p>
         Additionally, requests from an [=opaque origin=] are rejected. Calls to {{DigitalCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}}
         and {{DigitalCredential/[[Create]](origin, options, sameOriginWithAncestors)}}
-        from an [=opaque origin=] (such as `data:` URIs or sandboxed iframes) are
-        [=reject|rejected=], reducing the
-        risk of malicious extraction or spoofing from untrusted environments.
+        from an [=opaque origin=] (for example, a `data:` document, or a document
+        sandboxed without `allow-same-origin`) are [=reject|rejected=], reducing
+        the risk of malicious extraction or spoofing from untrusted environments.
       </p>
       <p>
         The Digital Credentials API reduces [=API flooding=] through two

--- a/index.html
+++ b/index.html
@@ -1899,12 +1899,11 @@
         [[[secure-contexts]]] specification for more information.
       </p>
       <p>
-        Additionally, the API is only available to documents with a non-opaque
-        origin. Calls to {{DigitalCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}}
-        and {{Credential/[[Create]](origin, options, sameOriginWithAncestors)}}
-        from [=opaque origins=] (such as `data:` URIs or sandboxed iframes) will
-        fail, reducing the risk of malicious extraction or spoofing from
-        untrusted environments.
+        Additionally, requests from an [=opaque origin=] are rejected. Calls to {{DigitalCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}}
+        and {{DigitalCredential/[[Create]](origin, options, sameOriginWithAncestors)}}
+        from an [=opaque origin=] (such as `data:` URIs or sandboxed iframes) will
+        be rejected with a {{"NotAllowedError"}} {{DOMException}}, reducing the
+        risk of malicious extraction or spoofing from untrusted environments.
       </p>
       <p>
         The Digital Credentials API reduces [=API flooding=] through two

--- a/index.html
+++ b/index.html
@@ -1709,7 +1709,7 @@
       with=] |signal|'s [=AbortSignal/abort reason=].
       </li>
       <li>If |origin| is an [=opaque origin=], return [=a promise rejected
-      with=] a {{"NotAllowedError"}} {{DOMException}}.
+      with=] a {{"SecurityError"}} {{DOMException}}.
       </li>
       <li>Let |global| be [=this=]'s [=relevant global object=].
       </li>

--- a/index.html
+++ b/index.html
@@ -1901,8 +1901,8 @@
       <p>
         Additionally, requests from an [=opaque origin=] are rejected. Calls to {{DigitalCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}}
         and {{DigitalCredential/[[Create]](origin, options, sameOriginWithAncestors)}}
-        from an [=opaque origin=] (such as `data:` URIs or sandboxed iframes) will
-        be rejected with a {{"NotAllowedError"}} {{DOMException}}, reducing the
+        from an [=opaque origin=] (such as `data:` URIs or sandboxed iframes) are
+        [=reject|rejected=], reducing the
         risk of malicious extraction or spoofing from untrusted environments.
       </p>
       <p>


### PR DESCRIPTION
Closes #???

Adds explicit verification steps in `[[DiscoverFromExternalSource]]` and `[[Create]]` algorithms to immediately reject requests from `opaque origins` (e.g. data URIs or sandboxed iframes) with a `NotAllowedError`.
Also updates the Mitigations prose to reflect this algorithmic protection.
Addresses parts of #233.

The following tasks have been completed:

- [x] Modified Web platform tests (https://github.com/web-platform-tests/wpt/pull/61188)

Implementation commitment:

- [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=318947)
- [x] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/535.html" title="Last updated on Jul 14, 2026, 7:47 AM UTC (f58defc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/535/900fd3f...f58defc.html" title="Last updated on Jul 14, 2026, 7:47 AM UTC (f58defc)">Diff</a>