### PR TITLE
Privacy: Add Data Clearing and Credential Availability protections

### DIFF
--- a/index.html
+++ b/index.html
@@ -2596,6 +2596,15 @@
           credentials from the user in order to access services, excluding
           individuals who are unwilling to present credentials.
         </p>
+        <p>
+          To ensure this protection is robust, [=user agents=] are expected to ensure that
+          errors returned by the API do not leak information about the user's
+          available credentials through observable differences, such as distinct
+          error types or timing attacks. For example, rejecting a request because
+          the user has no matching credentials is expected to return the same generic error
+          and take a similar amount of time as rejecting a request because the
+          user cancelled the prompt.
+        </p>
       </section>
       <section id="user-permission-and-transparency">
         <!--
@@ -2725,6 +2734,26 @@
           As more of this information becomes available in a structured format,
           we expect [=user agents=] and this specification to leverage it to
           improve the user permission experience as well.
+        </p>
+      </section>
+      <section>
+        <!--
+        // MARK: Data Clearing and Persistent State
+        -->
+        <h3>
+          Data Clearing and Persistent State
+        </h3>
+        <p>
+          The Digital Credentials API itself does not introduce new
+          browser-managed persistent state or local storage mechanisms. The
+          credentials requested through this API are stored and managed by external
+          [=credential managers=] or the operating system. Consequently, when a
+          user clears their browsing data (e.g., cookies or local storage) for a
+          given origin or globally, it generally does not clear or affect the
+          credentials held within those external managers. However, [=user agents=]
+          are expected to ensure that any temporary data, caches, or permissions specifically
+          tied to the API's intermediation are correctly cleared when the user
+          clears their site data.
         </p>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -2597,13 +2597,17 @@
           individuals who are unwilling to present credentials.
         </p>
         <p>
-          To ensure this protection is robust, [=user agents=] are expected to ensure that
+          To ensure this protection is robust, [=user agents=] MUST ensure that
           errors returned by the API do not leak information about the user's
           available credentials through observable differences, such as distinct
-          error types or timing attacks. For example, rejecting a request because
-          the user has no matching credentials is expected to return the same generic error
-          and take a similar amount of time as rejecting a request because the
-          user cancelled the prompt.
+          error types or timing attacks. For example, rejecting a request
+          because the user has no matching credentials MUST return the same
+          generic error as rejecting a request because the user cancelled the
+          prompt. Furthermore, to prevent timing attacks without relying on
+          artificial delays, [=user agents=] SHOULD present a user-facing
+          dialog (such as an empty chooser or notification) when no matching
+          credentials are found, so that prompt dismissal latency is
+          indistinguishable from user cancellation.
         </p>
       </section>
       <section id="user-permission-and-transparency">
@@ -2746,14 +2750,15 @@
         <p>
           The Digital Credentials API itself does not introduce new
           browser-managed persistent state or local storage mechanisms. The
-          credentials requested through this API are stored and managed by external
-          [=credential managers=] or the operating system. Consequently, when a
-          user clears their browsing data (e.g., cookies or local storage) for a
-          given origin or globally, it generally does not clear or affect the
-          credentials held within those external managers. However, [=user agents=]
-          are expected to ensure that any temporary data, caches, or permissions specifically
-          tied to the API's intermediation are correctly cleared when the user
-          clears their site data.
+          credentials requested through this API are stored and managed by
+          external [=credential managers=] or the operating system.
+          Consequently, when a user clears their browsing data (e.g., cookies
+          or local storage) for a given origin or globally, it generally does
+          not clear or affect the credentials held within those external
+          managers. However, [=user agents=] MUST ensure that any temporary
+          data, caches, or permissions specifically tied to the API's
+          intermediation are correctly cleared when the user clears their site
+          data.
         </p>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -2888,14 +2888,14 @@
           individuals who are unwilling to present credentials.
         </p>
         <p>
-          To ensure this protection is robust, [=user agents=] MUST ensure that
+          To ensure this protection is robust,
           errors returned by the API do not leak information about the user's
           available credentials through observable differences, such as distinct
           error types or timing attacks. For example, rejecting a request
-          because the user has no matching credentials MUST return the same
+          because the user has no matching credentials returns the same
           generic error as rejecting a request because the user cancelled the
           prompt. Furthermore, to prevent timing attacks without relying on
-          artificial delays, [=user agents=] SHOULD present a user-facing
+          artificial delays, [=user agents=] present a user-facing
           dialog (such as an empty chooser or notification) when no matching
           credentials are found, so that prompt dismissal latency is
           indistinguishable from user cancellation.
@@ -3046,10 +3046,7 @@
           Consequently, when a user clears their browsing data (e.g., cookies
           or local storage) for a given origin or globally, it generally does
           not clear or affect the credentials held within those external
-          managers. However, [=user agents=] MUST ensure that any temporary
-          data, caches, or permissions specifically tied to the API's
-          intermediation are correctly cleared when the user clears their site
-          data.
+          managers.
         </p>
       </section>
     </section>


### PR DESCRIPTION
Closes #???

Fills remaining gaps for the W3C Privacy Questionnaire:
- **Data Clearing**: Clarifies that clearing browser site data is expected to clear any API intermediation caches, though it won't clear credentials stored inside external managers/OS.
- **Avoiding leaks of credential availability**: States the expectation that User Agents return generic error types and normalize response timings so that websites cannot probabilistically determine if a user possesses a credential based on how fast the request is rejected.
Addresses parts of #232.

The following tasks have been completed:

- [ ] Modified Web platform tests (link)

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/536.html" title="Last updated on Aug 18, 2026, 2:20 PM UTC (95ca66c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/536/5ab9d18...95ca66c.html" title="Last updated on Aug 18, 2026, 2:20 PM UTC (95ca66c)">Diff</a>