### PR TITLE
Security: Add cross-device security and proximity considerations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1977,8 +1977,8 @@
           to mitigate remote relay attacks. Crucially, in a cross-device flow, the
           [=credential manager=] cannot inherently trust the [=origin=] string
           forwarded by the primary device, as the primary device or its browser
-          might be compromised. Therefore, protocols that employ signed requests—where
-          the [=verifier=] cryptographically proves its identity—provide
+          might be compromised. Therefore, protocols that employ signed requests, where
+          the [=verifier=] cryptographically proves its identity, provide
           significantly stronger security guarantees than relying solely on
           the browser-asserted [=origin=].
         </p>

--- a/index.html
+++ b/index.html
@@ -1968,7 +1968,7 @@
           laptop. Although the specific data exchange protocols (e.g.,
           cryptographic formats and transports) are out of scope for this API,
           such cross-device interactions typically rely on established protocols
-          like the Client to Authenticator Protocol (CTAP) ([[[FIDO-CLIENT-TO-AUTHENTICATOR-PROTOCOL-V2.2]]]).
+          like the Client to Authenticator Protocol (CTAP) ([[[FIDO-CLIENT-TO-AUTHENTICATOR-PROTOCOL-V2.3]]]).
         </p>
         <p>
           These protocols ensure security by establishing cryptographically secure

--- a/index.html
+++ b/index.html
@@ -1963,8 +1963,8 @@
         </h3>
         <p>
           The Digital Credentials API supports cross-device experiences where a
-          user presents a credential from a secondary device, such as a
-          smartphone acting as an authenticator, to a primary device, such as a
+          user presents a [=digital credential=] from a secondary device, such as a
+          smartphone acting as a [=credential manager=], to a primary device, such as a
           laptop. Although the specific data exchange protocols (e.g.,
           cryptographic formats and transports) are out of scope for this API,
           such cross-device interactions typically rely on established protocols
@@ -1974,12 +1974,12 @@
           These protocols ensure security by establishing cryptographically secure
           channels and enforcing physical proximity (e.g., via Bluetooth Low Energy)
           to mitigate remote relay attacks. Crucially, in a cross-device flow, the
-          authenticator device cannot inherently trust the `origin` string
+          [=credential manager=] cannot inherently trust the [=origin=] string
           forwarded by the primary device, as the primary device or its browser
           might be compromised. Therefore, protocols that employ signed requests—where
           the [=verifier=] cryptographically proves its identity—provide
           significantly stronger security guarantees than relying solely on
-          the browser-asserted origin.
+          the browser-asserted [=origin=].
         </p>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -1954,6 +1954,34 @@
         [[[permissions-policy]]] specification for additional security
         properties provided by this integration.
       </p>
+      <section>
+        <!--
+        // MARK: Cross-Device Security and Proximity
+        -->
+        <h3>
+          Cross-Device Security and Proximity
+        </h3>
+        <p>
+          The Digital Credentials API supports cross-device experiences where a
+          user presents a credential from a secondary device, such as a
+          smartphone acting as an authenticator, to a primary device, such as a
+          laptop. Although the specific data exchange protocols (e.g.,
+          cryptographic formats and transports) are out of scope for this API,
+          such cross-device interactions typically rely on established protocols
+          like the Client to Authenticator Protocol ([[[CTAP]]]).
+        </p>
+        <p>
+          These protocols ensure security by establishing cryptographically secure
+          channels and enforcing physical proximity (e.g., via Bluetooth Low Energy)
+          to mitigate remote relay attacks. Crucially, in a cross-device flow, the
+          authenticator device cannot inherently trust the `origin` string
+          forwarded by the primary device, as the primary device or its browser
+          might be compromised. Therefore, protocols that employ signed requests—where
+          the [=verifier=] cryptographically proves its identity—provide
+          significantly stronger security guarantees than relying solely on
+          the browser-asserted origin.
+        </p>
+      </section>
     </section>
     <section id="privacy-principles" class="informative" data-cite=
     "privacy-principles">

--- a/index.html
+++ b/index.html
@@ -1968,7 +1968,8 @@
           laptop. Although the specific data exchange protocols (e.g.,
           cryptographic formats and transports) are out of scope for this API,
           such cross-device interactions typically rely on established protocols
-          like the Client to Authenticator Protocol ([[[CTAP]]]).
+          like the Client to Authenticator Protocol (CTAP) / Proximity eXchange
+          Protocol (PXP) ([[[FIDO-CLIENT-TO-AUTHENTICATOR-PROTOCOL-V2.2]]]).
         </p>
         <p>
           These protocols ensure security by establishing cryptographically secure

--- a/index.html
+++ b/index.html
@@ -1968,8 +1968,7 @@
           laptop. Although the specific data exchange protocols (e.g.,
           cryptographic formats and transports) are out of scope for this API,
           such cross-device interactions typically rely on established protocols
-          like the Client to Authenticator Protocol (CTAP) / Proximity eXchange
-          Protocol (PXP) ([[[FIDO-CLIENT-TO-AUTHENTICATOR-PROTOCOL-V2.2]]]).
+          like the Client to Authenticator Protocol (CTAP) ([[[FIDO-CLIENT-TO-AUTHENTICATOR-PROTOCOL-V2.2]]]).
         </p>
         <p>
           These protocols ensure security by establishing cryptographically secure

--- a/index.html
+++ b/index.html
@@ -1979,7 +1979,7 @@
           forwarded by the primary device, as the primary device or its browser
           might be compromised. Therefore, protocols that employ signed requests, where
           the [=verifier=] cryptographically proves its identity, provide
-          significantly stronger security guarantees than relying solely on
+          significantly stronger security assurances than relying solely on
           the browser-asserted [=origin=].
         </p>
       </section>


### PR DESCRIPTION
Closes #369

Addresses #369 by adding a new non-normative section explaining the security guarantees of cross-device experiences.

Specifically, it clarifies:
- **Proximity and Transports:** The API delegates proximity checks and secure channels to underlying protocols like `CTAP` (and mentions BLE/NFC).
- **The Untrusted Origin Problem:** Explicitly states that in cross-device flows, the authenticator device cannot inherently trust the `origin` string passed by the requesting device since it may be compromised.
- **Signed Requests Mitigation:** Explains that because the origin cannot be trusted natively, protocols using signed requests provide much stronger security guarantees by having the verifier cryptographically prove their identity.


The following tasks have been completed:

- [ ] Modified Web platform tests (link)

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/538.html" title="Last updated on Jul 15, 2026, 6:29 PM UTC (f8ae21e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/538/1815f23...f8ae21e.html" title="Last updated on Jul 15, 2026, 6:29 PM UTC (f8ae21e)">Diff</a>