### PR TITLE
API: Recommend CTAP/PXP for cross-device credential exchanges

### DIFF
--- a/index.html
+++ b/index.html
@@ -1127,7 +1127,12 @@
               <li>The platform encounters an error.
               </li>
             </ul>
-            <aside class="issue" data-number="456"></aside>
+            <p>
+              When a [=user agent=] communicates with a [=credential manager=]
+              located on a different device, it is RECOMMENDED that [=user agents=]
+              use established, secure protocols such as the Client to Authenticator Protocol
+              (CTAP) / Proximity eXchange Protocol (PXP) ([[[FIDO-CLIENT-TO-AUTHENTICATOR-PROTOCOL-V2.2]]]).
+            </p>
           </li>
           <li>If |signal| is not null and |signal| is [=AbortSignal/aborted=]:
             <ol>

--- a/index.html
+++ b/index.html
@@ -1130,8 +1130,7 @@
             <p>
               When a [=user agent=] communicates with a [=credential manager=]
               located on a different device, it is RECOMMENDED that the [=user
-              agent=] use an established, secure protocol, such as the
-              [[[?FIDO-CLIENT-TO-AUTHENTICATOR-PROTOCOL-V2.2]]].
+              agent=] use [[[FIDO-CLIENT-TO-AUTHENTICATOR-PROTOCOL-V2.3]]].
             </p>
           </li>
           <li>If |signal| is not null and |signal| is [=AbortSignal/aborted=]:

--- a/index.html
+++ b/index.html
@@ -1129,9 +1129,10 @@
             </ul>
             <p>
               When a [=user agent=] communicates with a [=credential manager=]
-              located on a different device, it is RECOMMENDED that [=user agents=]
-              use established, secure protocols such as the Client to Authenticator Protocol
-              (CTAP) / Proximity eXchange Protocol (PXP) ([[[FIDO-CLIENT-TO-AUTHENTICATOR-PROTOCOL-V2.2]]]).
+              located on a different device, it is RECOMMENDED that the [=user agent=]
+              use an established, secure protocol, such as the Client to
+              Authenticator Protocol (CTAP) or the Proximity eXchange Protocol (PXP)
+              ([[[FIDO-CLIENT-TO-AUTHENTICATOR-PROTOCOL-V2.2]]]).
             </p>
           </li>
           <li>If |signal| is not null and |signal| is [=AbortSignal/aborted=]:

--- a/index.html
+++ b/index.html
@@ -1129,10 +1129,9 @@
             </ul>
             <p>
               When a [=user agent=] communicates with a [=credential manager=]
-              located on a different device, it is RECOMMENDED that the [=user agent=]
-              use an established, secure protocol, such as the Client to
-              Authenticator Protocol (CTAP) or the Proximity eXchange Protocol (PXP)
-              ([[[FIDO-CLIENT-TO-AUTHENTICATOR-PROTOCOL-V2.2]]]).
+              located on a different device, it is RECOMMENDED that the [=user
+              agent=] use an established, secure protocol, such as the
+              [[[?FIDO-CLIENT-TO-AUTHENTICATOR-PROTOCOL-V2.2]]].
             </p>
           </li>
           <li>If |signal| is not null and |signal| is [=AbortSignal/aborted=]:


### PR DESCRIPTION
Closes #456 

This PR addresses issue #456 by adding a normative recommendation for cross-device credential exchanges. It replaces the issue placeholder with guidance that user agents SHOULD use established, secure protocols like the Client to Authenticator Protocol (CTAP) / Proximity eXchange Protocol (PXP) when communicating with credential managers located on different devices.

This ensures broad interoperability and provides strong security properties such as proximity checks and cryptographically secure channels, while keeping the spec flexible enough for platform-specific capabilities.

The following tasks have been completed:

- [ ] Modified Web platform tests (link)

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/540.html" title="Last updated on Jul 16, 2026, 8:23 AM UTC (79fb68e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/540/e650a10...79fb68e.html" title="Last updated on Jul 16, 2026, 8:23 AM UTC (79fb68e)">Diff</a>