### PR TITLE
Add Internationalization Considerations section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2793,6 +2793,75 @@
         MUST be operable in a device-independent manner.
       </p>
     </section>
+    <section class="informative">
+      <!--
+      // MARK: Internationalization Considerations
+      -->
+      <h2>
+        Internationalization Considerations
+      </h2>
+      <p>
+        This API is agnostic to credential formats and exchange protocols, and
+        treats the request payloads ({{DigitalCredentialGetRequest}}'s
+        {{DigitalCredentialGetRequest/data}} and
+        {{DigitalCredentialCreateRequest}}'s
+        {{DigitalCredentialCreateRequest/data}}) and the response payload
+        ({{DigitalCredential}}'s {{DigitalCredential/data}}) as opaque. As a
+        result, the API defines no string-typed values that carry
+        human-readable, natural language content:
+      </p>
+      <ul>
+        <li>The string-typed values it defines, most notably [=digital
+        credential/protocol identifier|protocol identifiers=], are restricted to
+        ASCII ([=ASCII lower alpha=], U+002D HYPHEN-MINUS, and [=ASCII digit=])
+        and compared by exact equality. They are machine identifiers, not
+        human-readable text, so normalization, case folding, and language or
+        direction metadata do not apply.
+        </li>
+        <li>All payloads are exchanged as JSON and JavaScript values, with a
+        character encoding of UTF-8. Request payloads are serialized using
+        [=serialize a JavaScript value to a JSON string=], which calls the
+        ECMAScript `JSON.stringify` operation, and responses are parsed using
+        [=parse a JSON string to a JavaScript value=]. Because `JSON.stringify`
+        emits lone (unpaired) surrogate code points as `\uXXXX` escape
+        sequences, the serialized request is always well-formed, UTF-8-encodable
+        JSON.
+        </li>
+        <li>Human-readable, localizable credential content (for example, the
+        values of credential claims such as a name or address, including their
+        representation in different scripts and languages) is carried opaquely
+        within the credential payload. Its internationalization is determined by
+        the relevant credential format and [=digital credential/presentation
+        protocol=] or [=digital credential/issuance protocol=] (for example, the
+        formats defined in [[ISO18013-5]], and protocols such as [[OPENID4VP]]),
+        which this specification expects to provide language and direction
+        metadata, and localized alternatives, where appropriate.
+        </li>
+        <li>The one value the API routes to the platform that a [=user agent=]
+        may display is the requesting [=request context/top-level origin=].
+        Rendering an origin's host to the user, including the handling of
+        internationalized domain names and bidirectional text, follows the
+        [[[URL#url-rendering-i18n|host-rendering guidance in the URL Standard]]]
+        and is out of scope for this specification.
+        </li>
+        <li>Any other text presented to the user during a credential interaction
+        is rendered either by the website (using HTML, which provides language
+        and direction support through the host language), or by the platform's
+        [=digital credential chooser=]. The chooser is out of scope for this
+        specification; where it displays credential content, the language and
+        direction of that content, as provided by the credential format and
+        protocol, govern its presentation.
+        </li>
+      </ul>
+      <p>
+        Consequently, this specification introduces no natural language text
+        that requires language or direction metadata. Were a future revision to
+        introduce site-authored human-readable text at the API layer,
+        normatively defined permission prompt text, or a user-agent-drawn
+        presentation element, that text would need to carry, or be associated
+        with, appropriate language and direction metadata.
+      </p>
+    </section>
     <section data-cite="webdriver webdriver-bidi">
       <h2>
         Automated Testing

--- a/index.html
+++ b/index.html
@@ -2818,8 +2818,9 @@
         human-readable text, so normalization, case folding, and language or
         direction metadata do not apply.
         </li>
-        <li>All payloads are exchanged as JSON and JavaScript values, with a
-        character encoding of UTF-8. Request payloads are serialized using
+        <li>All payloads are exchanged as JSON text and JavaScript values. When a
+        JSON string is encoded as bytes (for example, for transport), it is
+        encoded using UTF-8. Request payloads are serialized using
         [=serialize a JavaScript value to a JSON string=], which calls the
         ECMAScript `JSON.stringify` operation, and responses are parsed using
         [=parse a JSON string to a JavaScript value=]. Because `JSON.stringify`
@@ -2833,7 +2834,7 @@
         within the credential payload. Its internationalization is determined by
         the relevant credential format and [=digital credential/presentation
         protocol=] or [=digital credential/issuance protocol=] (for example, the
-        formats defined in [[ISO18013-5]], and protocols such as [[OPENID4VP]]),
+        formats defined in [[[ISO18013-5]]], and protocols such as [[[OPENID4VP]]]),
         which this specification expects to provide language and direction
         metadata, and localized alternatives, where appropriate.
         </li>


### PR DESCRIPTION
Towards #231 (Internationalization horizontal review). This does not close that issue; it adds the Internationalization Considerations section that the self-review concluded was needed, and #231 stays open until the i18n WG review concludes.

Adds an informative "Internationalization Considerations" section. The Digital Credentials API is agnostic to credential formats and exchange protocols and treats request and response payloads as opaque, so it defines no human-readable natural-language text in its data model. The section records this: ASCII-only protocol identifiers, UTF-8/JSON payloads, localizable credential content delegated to the credential formats and protocols (for example ISO/IEC 18013-5 and OpenID4VP), origin (host) display deferred to the URL Standard's rendering guidance, and user-facing text rendered by the website in HTML or by the out-of-scope platform chooser.

The following tasks have been completed:

- [ ] Modified Web platform tests (link) — N/A: the section is informative and introduces no testable normative behaviour.

Implementation commitment:

- [ ] WebKit — N/A: no normative behavior change.
- [ ] Chromium — N/A: no normative behavior change.
- [ ] Gecko — N/A: no normative behavior change.

Documentation and checks

- [ ] Affects privacy — No.
- [ ] Affects security — No (informative; references the URL Standard's host-rendering and spoofing guidance, but adds no normative requirement).
- [ ] Pinged MDN — N/A.
- [ ] Updated Explainer — N/A.
- [ ] Updated digitalcredentials.dev — N/A.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/541.html" title="Last updated on Jul 9, 2026, 9:59 PM UTC (ad25c2d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/541/900fd3f...ad25c2d.html" title="Last updated on Jul 9, 2026, 9:59 PM UTC (ad25c2d)">Diff</a>