### PR TITLE
Expand Accessibility Considerations section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2839,7 +2839,7 @@
       </p>
       <p>
         Some platforms fulfil [=digital credential/presentation requests=] across
-        devices, for example by displaying a QR code for the user to scan with a
+        devices; for example, by displaying a QR code for the user to scan with a
         separate device. Because such flows can depend on vision, a camera, or
         the use of a second device, platforms SHOULD provide an equivalent and
         accessible means of completing the interaction that does not rely on a

--- a/index.html
+++ b/index.html
@@ -2859,8 +2859,8 @@
         impose a short limit that rushes the user.
         </li>
         <li>A proximity check is a security-essential, real-time constraint that
-        cannot be extended without defeating its purpose. In this case the
-        platform SHOULD make the remaining time programmatically determinable and
+        cannot be extended without defeating its purpose. In this case, the
+        platform SHOULD make the remaining time programmatically determinable, and
         SHOULD allow the user to retry the interaction.
         </li>
         <li>The validity window of a cross-device request SHOULD be extendable or

--- a/index.html
+++ b/index.html
@@ -2779,18 +2779,106 @@
         Accessibility Considerations
       </h2>
       <p>
-        Implementers need to consider accessibility when designing [=credential
-        choosers=] specifically for this API. The content of modal dialogs
-        presented during [=digital credential/issuance request|issuance=] or
-        [=digital credential/presentation requests|presentation=], which can
-        include text, QR codes, and other visual media, SHOULD be labelled and
-        exposed to assistive technologies.
+        The user interface for selecting and authorizing a [=digital
+        credential=] is provided by the platform and is largely outside the
+        scope of this specification; however, the accessibility of that
+        experience is within scope (see [[[#scope]]]). The following guidance
+        applies to [=user agents=] and platforms implementing the [=digital
+        credential chooser=] and the flows around it, and references the relevant
+        success criteria of [[WCAG22]]. Where the chooser is a non-web user
+        interface, those criteria apply as described in [[WCAG2ICT-22]].
       </p>
       <p>
-        Interactive elements, particularly those that allow the user to
-        continue or abort [=digital credential/issuance request|issuance=] or
-        [=digital credential/presentation requests|presentation=] requests,
-        MUST be operable in a device-independent manner.
+        The content of modal dialogs presented during [=digital
+        credential/issuance request|issuance=] or [=digital
+        credential/presentation requests|presentation=], which can include text,
+        QR codes, and other visual media, SHOULD be labelled and exposed to
+        assistive technologies with appropriate names, roles, and values (see
+        [[[WCAG22#name-role-value]]]), and SHOULD provide text alternatives for
+        non-text content (see [[[WCAG22#non-text-content]]]).
+      </p>
+      <p>
+        Changes in the state of an interaction, such as waiting for another
+        device, a successful response, an error, or cancellation, SHOULD be
+        programmatically determinable and conveyed to assistive technologies
+        without requiring a change of focus (see [[[WCAG22#status-messages]]]).
+      </p>
+      <p>
+        When an operation fails, the [=user agent=] rejects with one of several
+        distinct errors, for example a {{"NotAllowedError"}},
+        {{"InvalidStateError"}}, or {{"OperationError"}} {{DOMException}}, or a
+        {{TypeError}}. Where the platform surfaces such a failure to the user, it
+        SHOULD identify in text what went wrong and, where applicable, how to
+        recover, rather than only signalling that an error occurred (see
+        [[[WCAG22#error-identification]]]).
+      </p>
+      <p>
+        Interactive elements, particularly those that allow the user to continue
+        or abort an [=digital credential/issuance request|issuance=] or [=digital
+        credential/presentation requests|presentation=] request, MUST be operable
+        in a device-independent manner (for example, via the keyboard; see
+        [[[WCAG22#keyboard]]]). In particular, activation MUST NOT require a
+        multipoint or path-based gesture (see [[[WCAG22#pointer-gestures]]]) or
+        device motion (see [[[WCAG22#motion-actuation]]]) as the only means of
+        operation. The [=digital credential chooser=] SHOULD present its controls
+        in a meaningful focus order (see [[[WCAG22#focus-order]]]), move focus
+        into the chooser when it opens, keep focus within it while it is shown,
+        and restore focus to the previously focused element, or another
+        appropriate location, when it closes.
+      </p>
+      <p>
+        Where releasing a [=digital credential=] requires the [=holder=] to
+        authenticate, an accessible authentication method SHOULD be available.
+        Where a step relies on a cognitive function test, such as recalling a
+        password, an alternative that does not require one SHOULD be offered (see
+        [[[WCAG22#accessible-authentication-minimum]]]); and authentication SHOULD
+        NOT depend solely on a single physical characteristic, such as a
+        biometric, that some users cannot provide. This step is typically
+        performed by the platform or [=credential manager=] and is otherwise
+        outside the scope of this specification.
+      </p>
+      <p>
+        Some platforms fulfil [=digital credential/presentation requests=] across
+        devices, for example by displaying a QR code for the user to scan with a
+        separate device. Because such flows can depend on vision, a camera, or
+        the use of a second device, platforms SHOULD provide an equivalent and
+        accessible means of completing the interaction that does not rely on a
+        single sensory ability or input modality. A cross-device request conveyed
+        only through a visual artifact such as a QR code, with no accessible
+        alternative, excludes users who cannot use that modality.
+      </p>
+      <p>
+        An interaction may be subject to time limits from more than one source.
+        These SHOULD be handled so that users who need more time are not excluded
+        (see [[[WCAG22#timing-adjustable]]]):
+      </p>
+      <ul>
+        <li>A site can bound the interaction by passing an {{AbortSignal}} as
+        {{CredentialRequestOptions/signal}}, for example one created with
+        `AbortSignal.timeout()`. Sites SHOULD allow sufficient time and SHOULD NOT
+        impose a short limit that rushes the user.
+        </li>
+        <li>A proximity check is a security-essential, real-time constraint that
+        cannot be extended without defeating its purpose. In this case the
+        platform SHOULD make the remaining time programmatically determinable and
+        SHOULD allow the user to retry the interaction.
+        </li>
+        <li>The validity window of a cross-device request SHOULD be extendable or
+        able to be retried.
+        </li>
+      </ul>
+      <p>
+        The decision to review and disclose a [=digital credential=] SHOULD NOT
+        be subject to a forcing countdown, including time pressure inherited from
+        the surrounding site flow.
+      </p>
+      <p>
+        Human-readable credential content shown during an interaction, together
+        with any accessible alternatives for it such as text alternatives for
+        images, is carried within the credential payload and is the
+        responsibility of the relevant credential format and protocol. Those
+        formats and protocols also determine the language and direction of that
+        content.
       </p>
     </section>
     <section data-cite="webdriver webdriver-bidi">

--- a/index.html
+++ b/index.html
@@ -2805,7 +2805,7 @@
       </p>
       <p>
         When an operation fails, the [=user agent=] rejects with one of several
-        distinct errors, for example a {{"NotAllowedError"}},
+        distinct errors; for example, a {{"NotAllowedError"}},
         {{"InvalidStateError"}}, or {{"OperationError"}} {{DOMException}}, or a
         {{TypeError}}. Where the platform surfaces such a failure to the user, it
         SHOULD identify in text what went wrong and, where applicable, how to
@@ -2822,9 +2822,9 @@
         device motion (see [[[WCAG22#motion-actuation]]]) as the only means of
         operation. The [=digital credential chooser=] SHOULD present its controls
         in a meaningful focus order (see [[[WCAG22#focus-order]]]), move focus
-        into the chooser when it opens, keep focus within it while it is shown,
+        into the chooser when it is opened; keep focus within it while it is shown;
         and restore focus to the previously focused element, or another
-        appropriate location, when it closes.
+        appropriate location, when it is closed.
       </p>
       <p>
         Where releasing a [=digital credential=] requires the [=holder=] to
@@ -2854,7 +2854,7 @@
       </p>
       <ul>
         <li>A site can bound the interaction by passing an {{AbortSignal}} as
-        {{CredentialRequestOptions/signal}}, for example one created with
+        {{CredentialRequestOptions/signal}}; for example, one created with
         `AbortSignal.timeout()`. Sites SHOULD allow sufficient time and SHOULD NOT
         impose a short limit that rushes the user.
         </li>

--- a/index.html
+++ b/index.html
@@ -2799,7 +2799,7 @@
       </p>
       <p>
         Changes in the state of an interaction, such as waiting for another
-        device, a successful response, an error, or cancellation, SHOULD be
+        device, a successful response, an error, or a cancellation, SHOULD be
         programmatically determinable and conveyed to assistive technologies
         without requiring a change of focus (see [[[WCAG22#status-messages]]]).
       </p>


### PR DESCRIPTION
Towards #229 (Accessibility horizontal review). This does not close that issue; it expands the Accessibility Considerations section per the FAST self-review, and #229 stays open until the APA review concludes.

Expands the Accessibility Considerations section with guidance for the platform-provided credential chooser and the flows around it: labelling and name/role/value plus text alternatives, status messages, error identification tied to the API's error taxonomy, device-independent operation including pointer gestures and motion actuation, focus order and management, accessible authentication, an accessible alternative to visual-only cross-device (QR) interactions, and time limits covering a site-supplied AbortSignal, security-essential proximity checks, and session validity windows, without subjecting the disclosure decision to a forcing countdown. It references WCAG 2.2 success criteria and, for a non-web chooser UI, WCAG2ICT.

The following tasks have been completed:

- [ ] Modified Web platform tests (link) — N/A: the guidance applies to the platform-provided chooser UI, which is not exercised by web platform tests.

Implementation commitment:

- [ ] WebKit — N/A: no new web-facing normative API surface; the guidance targets platform/chooser UI.
- [ ] Chromium — N/A.
- [ ] Gecko — N/A.

Documentation and checks

- [ ] Affects privacy — No.
- [ ] Affects security — No (notes that proximity checks are security-essential, but adds no security requirement).
- [ ] Pinged MDN — N/A.
- [ ] Updated Explainer — N/A.
- [ ] Updated digitalcredentials.dev — N/A.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/542.html" title="Last updated on Jul 13, 2026, 11:17 PM UTC (b0bab03)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/542/900fd3f...b0bab03.html" title="Last updated on Jul 13, 2026, 11:17 PM UTC (b0bab03)">Diff</a>