### PR TITLE
Privacy Considerations: ecosystem note and per-protocol privacy review

### DIFF
--- a/index.html
+++ b/index.html
@@ -1999,6 +1999,30 @@
       </p>
       <section>
         <!--
+        // MARK: Ecosystem privacy
+        -->
+        <h3>
+          Ecosystem privacy
+        </h3>
+        <p>
+          This specification defines how a [=verifier=] interacts with a
+          user's [=credential manager=] through a [=user agent=]. The privacy
+          considerations in this section address that interaction and the
+          [=user agent duties=] it entails. They do not, and cannot, address
+          the privacy properties of a complete deployment that combines this
+          API with particular [=digital credential/presentation protocols=],
+          credential formats, issuance systems, and governance rules.
+        </p>
+        <p>
+          The privacy implications of such a deployment are out of scope for
+          this specification. Each deployment is encouraged to evaluate the
+          privacy implications across all of the specifications it uses, and to
+          consult the privacy considerations of those specifications, in
+          addition to the considerations described here.
+        </p>
+      </section>
+      <section>
+        <!--
         // MARK: Design Considerations and Alternatives
         -->
         <h3>
@@ -2251,6 +2275,102 @@
           responses in a credential exchange.
         </p>
         <p class="issue" data-number="109"></p>
+        <h4>
+          Privacy review of the supported protocols
+        </h4>
+        <p>
+          This section reviews how each [=digital credential/presentation
+          protocol=] listed in [[[#protocols]]] addresses the considerations
+          above, and notes where a property depends on deployment choices or is
+          left to the credential format. It is descriptive: it records the
+          state of the referenced protocol specifications at the time of
+          writing, not a conformance requirement.
+        </p>
+        <h5>
+          OpenID for Verifiable Presentations
+        </h5>
+        <p>
+          [[OPENID4VP]] facilitates selective disclosure through its query
+          language, allowing a [=verifier=] to request only the claims it
+          needs; the granularity actually achieved depends on the credential
+          format (for example, a salted-hash format). It does not provide
+          unlinkability as an inherent property: it addresses
+          verifier-to-verifier linkability only, and treats unlinkability as
+          achievable by presenting a single-use credential instance, with
+          batch issuance of such instances defined in [[OPENID4VCI]] rather
+          than in the presentation protocol itself. It does not define
+          zero-knowledge mechanisms. The core presentation exchange does not
+          require contacting the [=issuer=]; however, establishing trust in
+          the issuer (or in the framework that certifies issuers) can involve
+          online resolution that could enable profiling, and the protocol
+          advises wallets against retrieving unfamiliar URLs supplied in a
+          request. Revocation is not addressed beyond a verifier-side policy
+          check.
+        </p>
+        <p>
+          Verifier authorization is the main axis on which the three variants
+          ({{DigitalCredentialPresentationProtocol/"openid4vp-v1-unsigned"}}, {{DigitalCredentialPresentationProtocol/"openid4vp-v1-signed"}},
+          and {{DigitalCredentialPresentationProtocol/"openid4vp-v1-multisigned"}}) differ. An unsigned request
+          carries no cryptographic authentication of the verifier and relies on
+          the request [=origin=] and the Web PKI; a signed request lets the
+          wallet authenticate the verifier through a trust framework in addition
+          to the Web PKI, and binds the request to its expected origins to
+          detect replay; a multi-signed request extends this to multiple
+          verifier identities and trust frameworks for a single request. The
+          variants differ in verifier authentication strength, not in
+          presentation unlinkability.
+        </p>
+        <h5>
+          ISO/IEC mdoc ({{DigitalCredentialPresentationProtocol/"org-iso-mdoc"}})
+        </h5>
+        <p>
+          The mdoc data model ([[ISO18013-5]]) is element-granular: a
+          [=verifier=] requests individual data elements, and an mdoc need not
+          release an element merely because it is present, which supports data
+          minimization (for example, an age-over attestation can confirm a
+          threshold without revealing date of birth). As with [[OPENID4VP]],
+          unlinkability is not inherent: it depends on the issuer and wallet
+          rotating per-presentation keys and signed objects, and is described
+          as a recommendation rather than a guaranteed property. On the
+          Digital Credentials API path defined in [[ISO18013-7]] Annex C, the
+          presentation is a direct exchange between the wallet and the
+          verifier with no issuer contact, and the response is encrypted to
+          the verifier, so a [=user agent=] cannot inspect it. Revocation is
+          out of scope for [[ISO18013-7]]; freshness relies on the validity
+          window of the signed object, and [[ISO18013-5]] cautions that
+          revocation techniques can undermine unlinkability. The mechanism for
+          obtaining the holder's consent is out of scope, but the base
+          standard recommends informed, transaction-time consent rather than
+          blanket authorization. Verifier authentication (reader
+          authentication) is optional, while the Digital Credentials API path
+          additionally binds the request [=origin=] into the session and
+          requires the exchange to be aborted if the origin is absent, which
+          mitigates request-forwarding attacks that affect other invocation
+          mechanisms.
+        </p>
+        <h5>
+          OpenID for Verifiable Credential Issuance ({{DigitalCredentialIssuanceProtocol/"openid4vci-v1"}})
+        </h5>
+        <p>
+          [[OPENID4VCI]] is an [=digital credential/issuance protocol=], so
+          the presentation considerations above apply to it only indirectly.
+          For unlinkability it supports batch issuance of credentials bound to
+          distinct keys, which its own text describes as aiding
+          verifier-to-verifier unlinkability only; the issuer controls the
+          batch size. Beyond first issuance, the credential lifecycle can
+          involve further contact with the [=issuer=] (for example deferred
+          issuance, a notification endpoint, or non-interactive refresh), some
+          of which is optional. Data-minimization guidance is present but is
+          directed at limiting what a [=verifier=] later obtains and at
+          storage, rather than constraining what the issuer collects.
+        </p>
+        <p>
+          At the time of writing, no binding of {{DigitalCredentialIssuanceProtocol/"openid4vci-v1"}} to
+          the Digital Credentials API has been published; it is being developed
+          in the OpenID Foundation. This review is therefore limited to the
+          issuance protocol itself and is expected to be revisited once the
+          Digital Credentials API integration is defined.
+        </p>
       </section>
       <section>
         <!--

--- a/index.html
+++ b/index.html
@@ -2206,8 +2206,8 @@
           Ecosystem privacy
         </h3>
         <p>
-          This specification defines how a [=verifier=] interacts with a
-          user's [=credential manager=] through a [=user agent=]. The privacy
+          This specification defines how a [=verifier=] interacts with a user's
+          [=credential manager=] through a [=user agent=]. The privacy
           considerations in this section address that interaction and the
           [=user agent duties=] it entails. They do not, and cannot, address
           the privacy properties of a complete deployment that combines this
@@ -2480,11 +2480,11 @@
           Privacy review of the supported protocols
         </h4>
         <p>
-          This section reviews how each supported [=digital credential/presentation
-          protocol=] and [=digital credential/issuance protocol=] listed in
-          [[[#protocols]]] addresses the considerations above, and notes where a
-          property depends on deployment choices or is left to the credential
-          format. It is descriptive: it records the
+          This section reviews how each supported [=digital
+          credential/presentation protocol=] and [=digital credential/issuance
+          protocol=] listed in [[[#protocols]]] addresses the considerations
+          above, and notes where a property depends on deployment choices or is
+          left to the credential format. It is descriptive: it records the
           state of the referenced protocol specifications at the time of
           writing, not a conformance requirement.
         </p>
@@ -2498,32 +2498,33 @@
           format (for example, a salted-hash format). It does not provide
           unlinkability as an inherent property: it addresses
           verifier-to-verifier linkability only, and treats unlinkability as
-          achievable by presenting a single-use credential instance, with
-          batch issuance of such instances defined in [[OPENID4VCI]] rather
-          than in the presentation protocol itself. It does not define
-          zero-knowledge mechanisms. The core presentation exchange does not
-          require contacting the [=issuer=]; however, establishing trust in
-          the issuer (or in the framework that certifies issuers) can involve
-          online resolution that could enable profiling, and the protocol
-          advises wallets against retrieving unfamiliar URLs supplied in a
-          request. Revocation is not addressed beyond a verifier-side policy
-          check.
+          achievable by presenting a single-use credential instance, with batch
+          issuance of such instances defined in [[OPENID4VCI]] rather than in
+          the presentation protocol itself. It does not define zero-knowledge
+          mechanisms. The core presentation exchange does not require
+          contacting the [=issuer=]; however, establishing trust in the issuer
+          (or in the framework that certifies issuers) can involve online
+          resolution that could enable profiling, and the protocol advises
+          wallets against retrieving unfamiliar URLs supplied in a request.
+          Revocation is not addressed beyond a verifier-side policy check.
         </p>
         <p>
           Verifier authorization is the main axis on which the three variants
-          ({{DigitalCredentialPresentationProtocol/"openid4vp-v1-unsigned"}}, {{DigitalCredentialPresentationProtocol/"openid4vp-v1-signed"}},
-          and {{DigitalCredentialPresentationProtocol/"openid4vp-v1-multisigned"}}) differ. An unsigned request
-          carries no cryptographic authentication of the verifier and relies on
-          the request [=origin=] and the Web PKI; a signed request lets the
-          wallet authenticate the verifier through a trust framework in addition
-          to the Web PKI, and binds the request to its expected origins to
-          detect replay; a multi-signed request extends this to multiple
-          verifier identities and trust frameworks for a single request. The
-          variants differ in verifier authentication strength, not in
-          presentation unlinkability.
+          ({{DigitalCredentialPresentationProtocol/"openid4vp-v1-unsigned"}},
+          {{DigitalCredentialPresentationProtocol/"openid4vp-v1-signed"}}, and
+          {{DigitalCredentialPresentationProtocol/"openid4vp-v1-multisigned"}})
+          differ. An unsigned request carries no cryptographic authentication
+          of the verifier and relies on the request [=origin=] and the Web PKI;
+          a signed request lets the wallet authenticate the verifier through a
+          trust framework in addition to the Web PKI, and binds the request to
+          its expected origins to detect replay; a multi-signed request extends
+          this to multiple verifier identities and trust frameworks for a
+          single request. The variants differ in verifier authentication
+          strength, not in presentation unlinkability.
         </p>
         <h5>
-          ISO/IEC mdoc ({{DigitalCredentialPresentationProtocol/"org-iso-mdoc"}})
+          ISO/IEC mdoc
+          ({{DigitalCredentialPresentationProtocol/"org-iso-mdoc"}})
         </h5>
         <p>
           The mdoc data model ([[ISO18013-5]]) is element-granular: a
@@ -2533,30 +2534,30 @@
           threshold without revealing date of birth). As with [[OPENID4VP]],
           unlinkability is not inherent: it depends on the issuer and wallet
           rotating per-presentation keys and signed objects, and is described
-          as a recommendation rather than a guaranteed property. On the
-          Digital Credentials API path defined in [[ISO18013-7]] Annex C, the
-          presentation is a direct exchange between the wallet and the
-          verifier with no issuer contact, and the response is encrypted to
-          the verifier, so a [=user agent=] cannot inspect it. Revocation is
-          out of scope for [[ISO18013-7]]; freshness relies on the validity
-          window of the signed object, and [[ISO18013-5]] cautions that
-          revocation techniques can undermine unlinkability. The mechanism for
-          obtaining the holder's consent is out of scope, but the base
-          standard recommends informed, transaction-time consent rather than
-          blanket authorization. Verifier authentication (reader
-          authentication) is optional, while the Digital Credentials API path
-          additionally binds the request [=origin=] into the session and
-          requires the exchange to be aborted if the origin is absent, which
-          mitigates request-forwarding attacks that affect other invocation
-          mechanisms.
+          as a recommendation rather than a guaranteed property. On the Digital
+          Credentials API path defined in [[ISO18013-7]] Annex C, the
+          presentation is a direct exchange between the wallet and the verifier
+          with no issuer contact, and the response is encrypted to the
+          verifier, so a [=user agent=] cannot inspect it. Revocation is out of
+          scope for [[ISO18013-7]]; freshness relies on the validity window of
+          the signed object, and [[ISO18013-5]] cautions that revocation
+          techniques can undermine unlinkability. The mechanism for obtaining
+          the holder's consent is out of scope, but the base standard
+          recommends informed, transaction-time consent rather than blanket
+          authorization. Verifier authentication (reader authentication) is
+          optional, while the Digital Credentials API path additionally binds
+          the request [=origin=] into the session and requires the exchange to
+          be aborted if the origin is absent, which mitigates
+          request-forwarding attacks that affect other invocation mechanisms.
         </p>
         <h5>
-          OpenID for Verifiable Credential Issuance ({{DigitalCredentialIssuanceProtocol/"openid4vci-v1"}})
+          OpenID for Verifiable Credential Issuance
+          ({{DigitalCredentialIssuanceProtocol/"openid4vci-v1"}})
         </h5>
         <p>
-          [[OPENID4VCI]] is an [=digital credential/issuance protocol=], so
-          the presentation considerations above apply to it only indirectly.
-          For unlinkability it supports batch issuance of credentials bound to
+          [[OPENID4VCI]] is an [=digital credential/issuance protocol=], so the
+          presentation considerations above apply to it only indirectly. For
+          unlinkability it supports batch issuance of credentials bound to
           distinct keys, which its own text describes as aiding
           verifier-to-verifier unlinkability only; the issuer controls the
           batch size. Beyond first issuance, the credential lifecycle can
@@ -2567,11 +2568,12 @@
           storage, rather than constraining what the issuer collects.
         </p>
         <p>
-          At the time of writing, no binding of {{DigitalCredentialIssuanceProtocol/"openid4vci-v1"}} to
-          the Digital Credentials API has been published; it is being developed
-          in the OpenID Foundation. This review is therefore limited to the
-          issuance protocol itself and is expected to be revisited once the
-          Digital Credentials API integration is defined.
+          At the time of writing, no binding of
+          {{DigitalCredentialIssuanceProtocol/"openid4vci-v1"}} to the Digital
+          Credentials API has been published; it is being developed in the
+          OpenID Foundation. This review is therefore limited to the issuance
+          protocol itself and is expected to be revisited once the Digital
+          Credentials API integration is defined.
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -2567,7 +2567,7 @@
           directed at limiting what a [=verifier=] later obtains and at
           storage, rather than constraining what the issuer collects.
         </p>
-        <p>
+        <p class="note">
           At the time of writing, no binding of
           {{DigitalCredentialIssuanceProtocol/"openid4vci-v1"}} to the Digital
           Credentials API has been published; it is being developed in the

--- a/index.html
+++ b/index.html
@@ -2279,10 +2279,11 @@
           Privacy review of the supported protocols
         </h4>
         <p>
-          This section reviews how each [=digital credential/presentation
-          protocol=] listed in [[[#protocols]]] addresses the considerations
-          above, and notes where a property depends on deployment choices or is
-          left to the credential format. It is descriptive: it records the
+          This section reviews how each supported [=digital credential/presentation
+          protocol=] and [=digital credential/issuance protocol=] listed in
+          [[[#protocols]]] addresses the considerations above, and notes where a
+          property depends on deployment choices or is left to the credential
+          format. It is descriptive: it records the
           state of the referenced protocol specifications at the time of
           writing, not a conformance requirement.
         </p>


### PR DESCRIPTION
Closes #226

This adds two non-normative additions to the Privacy Considerations.

First, an "Ecosystem privacy" subsection clarifies that the privacy implications of a complete deployment that combines this API with particular presentation protocols, credential formats, issuance systems, and governance rules are out of scope for this specification, and that each deployment is encouraged to evaluate privacy across all of the specifications it uses and to consult their privacy considerations in addition to the considerations described here. This reflects the ecosystem-scope clarification discussed on the 2026-02-23 FedID call, based on text proposed by @gffletch in #226.

Second, a "Privacy review of the supported protocols" subsection reviews how each presentation and issuance protocol listed in the Protocols table addresses the considerations the section already sets out, and notes where a property depends on deployment choices or on the credential format rather than on the protocol itself. OpenID for Verifiable Presentations is reviewed across its unsigned, signed, and multi-signed request variants, which differ in verifier authentication strength rather than in presentation unlinkability. The mdoc review (ISO/IEC TS 18013-7 Annex C, building on ISO/IEC 18013-5) covers selective disclosure, the conditional nature of unlinkability, the origin binding the Digital Credentials API path adds, and the encrypted response. OpenID for Verifiable Credential Issuance is covered as an issuance protocol, with a note that its binding to the Digital Credentials API has not yet been published and that the review will be revisited once it is defined.

The review is descriptive: it records the current state of the referenced protocol specifications, not new conformance requirements. Concrete normative requirements are tracked separately in #255.

The following tasks have been completed:

- [ ] Modified Web platform tests (link) — N/A: non-normative prose, no testable behaviour.

Implementation commitment:

- [ ] WebKit (link to issue) — N/A: no normative or IDL change.
- [ ] Chromium (link to issue) — N/A
- [ ] Gecko (link to issue) — N/A

Documentation and checks

- [x] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN — N/A: no API-surface change.
- [ ] Updated Explainer — N/A
- [ ] Updated digitalcredentials.dev — N/A


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/543.html" title="Last updated on Aug 21, 2026, 2:34 AM UTC (a7d5e78)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/543/2e9b687...a7d5e78.html" title="Last updated on Aug 21, 2026, 2:34 AM UTC (a7d5e78)">Diff</a>