### PR TITLE
editorial: drop redundant pre-abort check in [[DiscoverFromExternalSource]]

### DIFF
--- a/index.html
+++ b/index.html
@@ -1648,9 +1648,6 @@
       <li>Let |signal| be |options|'s {{CredentialRequestOptions/signal}}, if
       present.
       </li>
-      <li>If |signal| is [=AbortSignal/aborted=], return [=a promise rejected
-      with=] |signal|'s [=AbortSignal/abort reason=].
-      </li>
       <li>Let |global| be [=this=]'s [=relevant global object=].
       </li>
       <li>Let |document| be |global|'s [=associated `Document`=].


### PR DESCRIPTION
Credential Management's "Request a `Credential`" already rejects a pre-aborted signal (with the same abort reason) before `[[DiscoverFromExternalSource]]` runs, so this method's own pre-abort check never fired. Removes that dead check; no observable behavior change.

The following tasks have been completed:

- [x] ~~Modified Web platform tests~~ — no observable behavior change; existing abort tests (e.g. `user-activation-get.https.html` early-abort) still pass, the pre-abort is now handled by Credential Management's "Request a `Credential`".

Implementation commitment: n/a (editorial, no behavior change).

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/547.html" title="Last updated on Jun 25, 2026, 8:37 PM UTC (7167367)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/547/8ff9184...7167367.html" title="Last updated on Jun 25, 2026, 8:37 PM UTC (7167367)">Diff</a>