### PR TITLE
fix: abort a waiting request when its document is torn down

### DIFF
--- a/index.html
+++ b/index.html
@@ -926,6 +926,10 @@
           </li>
         </ol>
       </li>
+      <li>If |document| stops being [=Document/fully active=], [=credential
+      request coordinator/abort the credential request=] with an
+      {{"AbortError"}} {{DOMException}}.
+      </li>
       <li>Let |handled| be the result of running [=handle virtual wallet
       behavior=] given |promise| and |global|.
       </li>
@@ -933,10 +937,6 @@
       </li>
       <li>[=credential request coordinator/Initiate the credential request=]
       with |document|, |validatedRequests|, |promise|, and |signal|.
-      </li>
-      <li>If |document| stops being [=Document/fully active=], [=credential
-      request coordinator/abort the credential request=] with an
-      {{"AbortError"}} {{DOMException}}.
       </li>
     </ol><!--
     // MARK: Validate credential requests


### PR DESCRIPTION
The "stops being fully active" abort step was sequenced after the early return for a handled virtual-wallet behavior, so a "wait" action left the request unable to abort on teardown. Moving it ahead of "handle virtual wallet behavior" arms it for every path.

The following tasks have been completed:

- [ ] Modified Web platform tests (link)

Implementation commitment:

- [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=306292)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/549.html" title="Last updated on Jun 30, 2026, 6:55 AM UTC (f43e5ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/549/1b5612a...f43e5ad.html" title="Last updated on Jun 30, 2026, 6:55 AM UTC (f43e5ad)">Diff</a>