### PR TITLE
Issuance request forwarding: Documenting the threat

### DIFF
--- a/index.html
+++ b/index.html
@@ -1862,6 +1862,17 @@
           explicit permission from the embedding site, potentially enabling
           credential harvesting or unauthorized access to sensitive user data.
         </dd>
+        <dt>
+          <strong>Issuance Request Forwarding</strong>
+        </dt>
+        <dd>
+          A malicious [=holder's=] [=credential manager=], such as a digital
+          wallet, selected by the user for a [=digital credential/issuance
+          request=], forwards the [=digital credential/issuance request data=]
+          to another [=credential manager=] on a device under attacker control,
+          causing issuance to complete with that other credential manager
+          rather than with the credential manager selected by the user.
+        </dd>
       </dl>
       <h4>
         Out of Scope Threats

--- a/index.html
+++ b/index.html
@@ -2003,7 +2003,7 @@
           carefully crafted or malformed protocol requests through the API.
         </dd>
         <dt>
-          <strong>Issuance Request Forwarding</strong>
+          <dfn>Issuance Request Forwarding</dfn>
         </dt>
         <dd>
           A malicious [=holder's=] [=credential manager=], such as a digital

--- a/index.html
+++ b/index.html
@@ -2002,6 +2002,17 @@
           underlying operating system or [=credential manager=] by passing
           carefully crafted or malformed protocol requests through the API.
         </dd>
+        <dt>
+          <strong>Issuance Request Forwarding</strong>
+        </dt>
+        <dd>
+          A malicious [=holder's=] [=credential manager=], such as a digital
+          wallet, selected by the user for a [=digital credential/issuance
+          request=], forwards the [=digital credential/issuance request data=]
+          to another [=credential manager=] on a device under attacker control,
+          causing issuance to complete with that other credential manager
+          rather than with the credential manager selected by the user.
+        </dd>
       </dl>
       <h4>
         Out of Scope Threats


### PR DESCRIPTION
This PR adds the issuance request forwarding threat to the Security Considerations threat model.

The threat captures the case discussed in #382 where a malicious holder's credential manager, such as a digital wallet, is selected by the user during issuance and forwards the issuance request data to another credential manager on an attacker-controlled device.

Addressing this threat remains under discussion in #382.

Related to #382.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/550.html" title="Last updated on Jul 8, 2026, 8:44 PM UTC (953517e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/550/1b5612a...953517e.html" title="Last updated on Jul 8, 2026, 8:44 PM UTC (953517e)">Diff</a>