### PR TITLE
Skip requests that fail validation instead of throwing

### DIFF
--- a/index.html
+++ b/index.html
@@ -994,12 +994,10 @@
                 during validation.
               </p>
             </aside>
-            <aside class="issue" data-number="472"></aside>
             <ol>
-              <li>If validation fails, [=exception/throw=] an appropriate
-              [=exception=].
+              <li>If validation fails, [=iteration/continue=].
               </li>
-              <li>Otherwise, [=list/append=] |request| to |validatedRequests|.
+              <li>[=list/append=] |request| to |validatedRequests|.
               </li>
             </ol>
           </li>


### PR DESCRIPTION
Resolves #472.

A request that fails protocol-specific validation is now skipped (like an unsupported protocol) rather than throwing; the call rejects with a TypeError only when no requests survive validation, matching the drop-and-continue behavior implementations use.

The following tasks have been completed:

- [x] ~~Modified Web platform tests~~ — not testable yet. Protocol-specific validation is explicitly out of scope for this spec, and simulating a validation failure through virtual wallet automation is tracked in #498. The sibling skip paths (unsupported and malformed protocols) are already covered by [protocol-filtering-openid4vp.https.html](https://github.com/web-platform-tests/wpt/blob/master/digital-credentials/protocol-filtering-openid4vp.https.html) and [protocol-filtering-mdoc.https.html](https://github.com/web-platform-tests/wpt/blob/master/digital-credentials/protocol-filtering-mdoc.https.html).

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Note that WebKit skips a request whose protocol it does not support, but propagates the exception when a supported request's data fails to convert, so it rejects the whole call rather than skipping that request.

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/554.html" title="Last updated on Aug 21, 2026, 6:41 AM UTC (9550db8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/554/2e9b687...9550db8.html" title="Last updated on Aug 21, 2026, 6:41 AM UTC (9550db8)">Diff</a>