### PR TITLE
Explain error behavior in WebDriver extension

### DIFF
--- a/index.html
+++ b/index.html
@@ -3157,6 +3157,36 @@
         <li>Return [=success=] with data `null`.
         </li>
       </ol>
+      <p class="note" title="Simulating wallet errors in tests">
+        Developers writing automated tests can simulate wallet errors by
+        passing an {{AbortSignal}} to {{CredentialsContainer/get()}} or
+        {{CredentialsContainer/create()}} and then aborting it with the desired
+        exception. This exercises the same abort path used by the request
+        algorithms.
+      </p>
+      <pre class="example js" title=
+      "Simulating a wallet error with AbortController">
+        const controller = new AbortController();
+        const credentialPromise = navigator.credentials.get({
+          digital: {
+            requests: [{
+              protocol: "example-request-protocol",
+              data: { /* presentation request data */ }
+            }]
+          },
+          signal: controller.signal
+        });
+
+        controller.abort(
+          new DOMException("Simulated wallet failure", "OperationError")
+        );
+
+        try {
+          await credentialPromise;
+        } catch (error) {
+          console.assert(error.name === "OperationError");
+        }
+      </pre>
       <h3>
         Handle Virtual Wallet Behavior
       </h3>

--- a/index.html
+++ b/index.html
@@ -3019,13 +3019,14 @@
         Types
       </h4>
       <pre class="cddl" data-cddl-module="remote-cddl">
-        digitalCredentials.VirtualWalletAction = "decline" / "respond" / "wait" / "clear"
+        digitalCredentials.VirtualWalletAction = "decline" / "respond" / "wait" / "clear" / "error"
 
         digitalCredentials.SetVirtualWalletBehaviorParameters = {
           action: digitalCredentials.VirtualWalletAction,
           ? context: text,
           ? protocol: text,
           ? response: { * text =&gt; any },
+          ? error: text,
         }
       </pre>
       <p>
@@ -3060,6 +3061,12 @@
         </dt>
         <dd>
           Clears the active virtual wallet behavior.
+        </dd>
+        <dt>
+          {^digitalCredentials.VirtualWalletAction/"error"^}
+        </dt>
+        <dd>
+          The virtual wallet simulates a wallet error.
         </dd>
       </dl>
       <h4>
@@ -3106,6 +3113,9 @@
         <li>Let |response| be |command parameters|["`response`"], if present,
         and `null` otherwise.
         </li>
+        <li>Let |error| be |command parameters|["`error`"], if present, and
+        `null` otherwise.
+        </li>
         <li>If |action| is `"respond"`:
           <ol>
             <li>If |protocol| is `null` or |response| is `null`, return an
@@ -3123,10 +3133,18 @@
             </li>
           </ol>
         </li>
+        <li>Else if |action| is `"error"`:
+          <ol>
+            <li>If |protocol| is not `null` or |response| is not `null`, return
+            an [=error=] with [=error code=] [=invalid argument=].
+            </li>
+          </ol>
+        </li>
         <li>Else:
           <ol>
-            <li>If |response| is not `null` or |protocol| is not `null`, return
-            an [=error=] with [=error code=] [=invalid argument=].
+            <li>If |protocol| is not `null`, |response| is not `null`, or
+            |error| is not `null`, return an [=error=] with [=error code=]
+            [=invalid argument=].
             </li>
           </ol>
         </li>
@@ -3143,7 +3161,7 @@
         <li>Else:
           <ol>
             <li>Let |behavior| be a tuple of (|action|, |protocol|,
-            |response|).
+            |response|, |error|).
             </li>
             <li>If |context| is not `null`, set the WebDriver [=session=]'s
             <dfn>active virtual wallet behavior</dfn> for the browsing context
@@ -3177,7 +3195,7 @@
         </li>
         <li>If |behavior| is `null`, return `false`.
         </li>
-        <li>Let (|action|, |protocol|, |response|) be |behavior|.
+        <li>Let (|action|, |protocol|, |response|, |error|) be |behavior|.
         </li>
         <li>If |action| is `"wait"`, return `true`.
         </li>
@@ -3185,6 +3203,18 @@
           <ol>
             <li>[=Reject=] |promise| with a {{"NotAllowedError"}}
             {{DOMException}}.
+            </li>
+            <li>Return `true`.
+            </li>
+          </ol>
+        </li>
+        <li>If |action| is `"error"`:
+          <ol>
+            <li>Let |errorName| be |error| if |error| is not `null`, or
+            `"UnknownError"` otherwise.
+            </li>
+            <li>[=Reject=] |promise| with a {{DOMException}} whose name is
+            |errorName|.
             </li>
             <li>Return `true`.
             </li>

--- a/index.html
+++ b/index.html
@@ -3019,14 +3019,13 @@
         Types
       </h4>
       <pre class="cddl" data-cddl-module="remote-cddl">
-        digitalCredentials.VirtualWalletAction = "decline" / "respond" / "wait" / "clear" / "error"
+        digitalCredentials.VirtualWalletAction = "decline" / "respond" / "wait" / "clear"
 
         digitalCredentials.SetVirtualWalletBehaviorParameters = {
           action: digitalCredentials.VirtualWalletAction,
           ? context: text,
           ? protocol: text,
           ? response: { * text =&gt; any },
-          ? error: text,
         }
       </pre>
       <p>
@@ -3061,12 +3060,6 @@
         </dt>
         <dd>
           Clears the active virtual wallet behavior.
-        </dd>
-        <dt>
-          {^digitalCredentials.VirtualWalletAction/"error"^}
-        </dt>
-        <dd>
-          The virtual wallet simulates a wallet error.
         </dd>
       </dl>
       <h4>
@@ -3113,9 +3106,6 @@
         <li>Let |response| be |command parameters|["`response`"], if present,
         and `null` otherwise.
         </li>
-        <li>Let |error| be |command parameters|["`error`"], if present, and
-        `null` otherwise.
-        </li>
         <li>If |action| is `"respond"`:
           <ol>
             <li>If |protocol| is `null` or |response| is `null`, return an
@@ -3133,18 +3123,10 @@
             </li>
           </ol>
         </li>
-        <li>Else if |action| is `"error"`:
-          <ol>
-            <li>If |protocol| is not `null` or |response| is not `null`, return
-            an [=error=] with [=error code=] [=invalid argument=].
-            </li>
-          </ol>
-        </li>
         <li>Else:
           <ol>
-            <li>If |protocol| is not `null`, |response| is not `null`, or
-            |error| is not `null`, return an [=error=] with [=error code=]
-            [=invalid argument=].
+            <li>If |response| is not `null` or |protocol| is not `null`, return
+            an [=error=] with [=error code=] [=invalid argument=].
             </li>
           </ol>
         </li>
@@ -3161,7 +3143,7 @@
         <li>Else:
           <ol>
             <li>Let |behavior| be a tuple of (|action|, |protocol|,
-            |response|, |error|).
+            |response|).
             </li>
             <li>If |context| is not `null`, set the WebDriver [=session=]'s
             <dfn>active virtual wallet behavior</dfn> for the browsing context
@@ -3195,7 +3177,7 @@
         </li>
         <li>If |behavior| is `null`, return `false`.
         </li>
-        <li>Let (|action|, |protocol|, |response|, |error|) be |behavior|.
+        <li>Let (|action|, |protocol|, |response|) be |behavior|.
         </li>
         <li>If |action| is `"wait"`, return `true`.
         </li>
@@ -3203,18 +3185,6 @@
           <ol>
             <li>[=Reject=] |promise| with a {{"NotAllowedError"}}
             {{DOMException}}.
-            </li>
-            <li>Return `true`.
-            </li>
-          </ol>
-        </li>
-        <li>If |action| is `"error"`:
-          <ol>
-            <li>Let |errorName| be |error| if |error| is not `null`, or
-            `"UnknownError"` otherwise.
-            </li>
-            <li>[=Reject=] |promise| with a {{DOMException}} whose name is
-            |errorName|.
             </li>
             <li>Return `true`.
             </li>

--- a/index.html
+++ b/index.html
@@ -3159,33 +3159,35 @@
       </ol>
       <p class="note" title="Simulating wallet errors in tests">
         Developers writing automated tests can simulate wallet errors by
-        passing an {{AbortSignal}} to {{CredentialsContainer/get()}} or
-        {{CredentialsContainer/create()}} and then aborting it with the desired
-        exception. This exercises the same abort path used by the request
-        algorithms.
+        passing an {{AbortSignal}} as {{CredentialRequestOptions/signal}} (for
+        {{CredentialsContainer/get()}}) or {{CredentialCreationOptions/signal}}
+        (for {{CredentialsContainer/create()}}), then aborting it with the
+        desired [=AbortSignal/abort reason=]. This exercises the same abort path used by the request algorithms.
       </p>
       <pre class="example js" title=
       "Simulating a wallet error with AbortController">
-        const controller = new AbortController();
-        const credentialPromise = navigator.credentials.get({
-          digital: {
-            requests: [{
-              protocol: "example-request-protocol",
-              data: { /* presentation request data */ }
-            }]
-          },
-          signal: controller.signal
-        });
+        (async () => {
+          const controller = new AbortController();
+          const credentialPromise = navigator.credentials.get({
+            digital: {
+              requests: [{
+                protocol: "example-request-protocol",
+                data: { /* presentation request data */ }
+              }]
+            },
+            signal: controller.signal
+          });
 
-        controller.abort(
-          new DOMException("Simulated wallet failure", "OperationError")
-        );
+          controller.abort(
+            new DOMException("Simulated wallet failure", "OperationError")
+          );
 
-        try {
-          await credentialPromise;
-        } catch (error) {
-          console.assert(error.name === "OperationError");
-        }
+          try {
+            await credentialPromise;
+          } catch (error) {
+            console.assert(error.name === "OperationError");
+          }
+        })();
       </pre>
       <h3>
         Handle Virtual Wallet Behavior


### PR DESCRIPTION
This pull request adds documentation to help developers simulate wallet errors when writing automated tests. The main change is a new note and code example in the `index.html` file, demonstrating how to use `AbortController` and `AbortSignal` to trigger wallet error scenarios in tests.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/556.html" title="Last updated on Aug 3, 2026, 1:27 AM UTC (ea73249)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/556/518f026...ea73249.html" title="Last updated on Aug 3, 2026, 1:27 AM UTC (ea73249)">Diff</a>