### PR TITLE
Fail with InvalidStateError when the document is not fully active at call time

### DIFF
--- a/index.html
+++ b/index.html
@@ -1659,6 +1659,9 @@
       </li>
       <li>Let |document| be |global|'s [=associated `Document`=].
       </li>
+      <li>If |document| is not [=Document/fully active=], return [=a promise
+      rejected with=] an {{"InvalidStateError"}} {{DOMException}}.
+      </li>
       <li>If |document| is not a [=Document/fully active descendant of a
       top-level traversable with user attention=], return [=a promise rejected
       with=] a {{"NotAllowedError"}} {{DOMException}}.
@@ -1718,6 +1721,9 @@
       <li>Let |global| be [=this=]'s [=relevant global object=].
       </li>
       <li>Let |document| be |global|'s [=associated `Document`=].
+      </li>
+      <li>If |document| is not [=Document/fully active=], return [=a promise
+      rejected with=] an {{"InvalidStateError"}} {{DOMException}}.
       </li>
       <li>If |document| is not a [=Document/fully active descendant of a
       top-level traversable with user attention=], return [=a promise rejected


### PR DESCRIPTION
Refs #112.

Per [§2.13 Handle non-fully-active documents](https://www.w3.org/TR/design-principles/#handle-non-fully-active-documents) in the TAG Design Principles, an operation whose associated document is not fully active at call time must fail immediately, with `InvalidStateError` suggested. This adds that check to `[[DiscoverFromExternalSource]]` and `[[Create]]` ahead of the existing user-attention check, so not being fully active is now `InvalidStateError`, lacking user attention stays `NotAllowedError`, and losing full activity mid-request stays `AbortError`.

The following tasks have been completed:

- [x] Modified Web platform tests — none needed: [get-non-fully-active.https.html](https://github.com/web-platform-tests/wpt/blob/master/digital-credentials/get-non-fully-active.https.html) and [create-non-fully-active.https.html](https://github.com/web-platform-tests/wpt/blob/master/digital-credentials/create-non-fully-active.https.html) already assert `InvalidStateError` for this case. They exercise the equivalent check in [Credential Management](https://w3c.github.io/webappsec-credential-management/#algorithm-request), which runs first, so the step added here is only reachable in the window before this algorithm runs in parallel and is not deterministically testable from script.

Implementation commitment:

- [x] WebKit — already implemented: [bug 274444](https://bugs.webkit.org/show_bug.cgi?id=274444)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

No new work is expected from this change: engines invoke the digital-credential algorithm synchronously from `get()`/`create()`, so none can observe a document that was fully active at the Credential Management check but not at this one.

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/digital-credentials/pull/557.html" title="Last updated on Aug 19, 2026, 2:55 AM UTC (65b3b64)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/557/494315a...marcoscaceres:65b3b64.html" title="Last updated on Aug 19, 2026, 2:55 AM UTC (65b3b64)">Diff</a>