### PR TITLE
Filter requests to supported protocols before consuming user activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -888,15 +888,6 @@
           </li>
         </ol>
       </li>
-      <li>If |validatedRequests| [=list/is empty=], then:
-        <ol>
-          <li>[=credential request coordinator/Reject the credential request
-          with=] a newly created {{TypeError}} and |promise|.
-          </li>
-          <li>Return.
-          </li>
-        </ol>
-      </li>
       <li>If |signal| was passed, then:
         <ol>
           <li>Assert: |signal| is not [=AbortSignal/aborted=].
@@ -940,6 +931,44 @@
       with |document|, |validatedRequests|, |promise|, and |signal|.
       </li>
     </ol><!--
+    // MARK: Filter credential requests
+    -->
+    <h3>
+      Filter credential requests
+    </h3>
+    <p>
+      To <dfn data-dfn-for="credential request coordinator">filter credential
+      requests</dfn> given a sequence of {{DigitalCredentialGetRequest}} or
+      {{DigitalCredentialCreateRequest}} objects |requests|:
+    </p>
+    <ol class="algorithm">
+      <li>Let |supportedRequests| be a new empty [=list=].
+      </li>
+      <li>[=List/For each=] |request| of |requests|:
+        <ol>
+          <li>Let |protocol| be the result of running [=convert request
+          protocol=] given |request|.
+          </li>
+          <li>If |protocol| is failure, [=iteration/continue=].
+          </li>
+          <li>If [=user agent allows protocol=] given |protocol| returns
+          `false`, [=iteration/continue=].
+          </li>
+          <li>[=list/Append=] |request| to |supportedRequests|.
+          </li>
+        </ol>
+      </li>
+      <li>Return |supportedRequests|.
+      </li>
+    </ol>
+    <p class="note">
+      Filtering happens before [=Consume user activation|consuming user
+      activation=] so that a request whose protocols are all unsupported is
+      rejected with a {{TypeError}} without consuming the user activation. As
+      the resulting list contains only requests with a supported protocol, the
+      protocol filtering in [=credential request coordinator/validate credential
+      requests=] is not repeated.
+    </p><!--
     // MARK: Validate credential requests
     -->
     <h3>
@@ -955,14 +984,6 @@
       </li>
       <li>[=List/For each=] |request| of |requests|:
         <ol>
-          <li>Let |protocol| be the result of running [=convert request
-          protocol=] given |request|.
-          </li>
-          <li>If |protocol| is failure, [=iteration/continue=].
-          </li>
-          <li>If [=user agent allows protocol=] given |protocol| returns
-          `false`, [=iteration/continue=].
-          </li>
           <li>Let |data| be |request|'s {{DigitalCredentialGetRequest/data}},
           if |request| is a {{DigitalCredentialGetRequest}}, or |request|'s
           {{DigitalCredentialCreateRequest/data}}, if |request| is a
@@ -1666,6 +1687,12 @@
       <li>Let |requests| be |options|'s {{CredentialRequestOptions/digital}}'s
       {{DigitalCredentialRequestOptions/requests}} member.
       </li>
+      <li>Set |requests| to the result of [=credential request
+      coordinator/filter credential requests=] given |requests|.
+      </li>
+      <li>If |requests| [=list/is empty=], return [=a promise rejected with=] a
+      newly created {{TypeError}}.
+      </li>
       <li>If |global| does not have [=transient activation=], return [=a
       promise rejected with=] a {{"NotAllowedError"}} {{DOMException}}.
       </li>
@@ -1725,6 +1752,12 @@
       </li>
       <li>Let |requests| be |options|'s {{CredentialCreationOptions/digital}}'s
       {{DigitalCredentialCreationOptions/requests}} member.
+      </li>
+      <li>Set |requests| to the result of [=credential request
+      coordinator/filter credential requests=] given |requests|.
+      </li>
+      <li>If |requests| [=list/is empty=], return [=a promise rejected with=] a
+      newly created {{TypeError}}.
       </li>
       <li>If |global| does not have [=transient activation=], return [=a
       promise rejected with=] a {{"NotAllowedError"}} {{DOMException}}.

--- a/index.html
+++ b/index.html
@@ -964,10 +964,9 @@
     <p class="note">
       Filtering happens before [=Consume user activation|consuming user
       activation=] so that a request whose protocols are all unsupported is
-      rejected with a {{TypeError}} without consuming the user activation. As
-      the resulting list contains only requests with a supported protocol, the
-      protocol filtering in [=credential request coordinator/validate credential
-      requests=] is not repeated.
+      rejected with a {{TypeError}} without consuming the user activation. 
+      Subsequent validation in [=credential request coordinator/validate credential requests=] 
+      can safely assume all remaining requests use supported protocols.
     </p><!--
     // MARK: Validate credential requests
     -->

--- a/index.html
+++ b/index.html
@@ -1714,9 +1714,6 @@
       </li>
       <li>Let |global| be [=this=]'s [=relevant global object=].
       </li>
-      <li>If |global| does not have [=transient activation=], return [=a
-      promise rejected with=] a {{"NotAllowedError"}} {{DOMException}}.
-      </li>
       <li>Return the result of [=credential request coordinator/prepare
       credential requests=] given |global|, |origin|, |requests|, and |signal|.
       </li>
@@ -1761,9 +1758,6 @@
       present.
       </li>
       <li>Let |global| be [=this=]'s [=relevant global object=].
-      </li>
-      <li>If |global| does not have [=transient activation=], return [=a
-      promise rejected with=] a {{"NotAllowedError"}} {{DOMException}}.
       </li>
       <li>Return the result of [=credential request coordinator/prepare
       credential requests=] given |global|, |origin|, |requests|, and |signal|.


### PR DESCRIPTION
matching Chrome

The following tasks have been completed:

- [ ] Modified Web platform tests (link)

Implementation commitment:

- [x] WebKit (WebKit/WebKit#69766)
- [X] Chromium
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [x] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/558.html" title="Last updated on Aug 19, 2026, 6:18 PM UTC (5e20604)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/558/7e762a8...5e20604.html" title="Last updated on Aug 19, 2026, 6:18 PM UTC (5e20604)">Diff</a>