### PR TITLE
Restore the origin-bound declaration on DigitalCredential

### DIFF
--- a/index.html
+++ b/index.html
@@ -1513,6 +1513,9 @@
       static boolean userAgentAllowsProtocol(DOMString protocol);
     };
     </pre>
+    <p>
+      {{DigitalCredential}} instances are [=Credential/origin bound=].
+    </p>
     <h4>
       The `protocol` member
     </h4>
@@ -1652,9 +1655,6 @@
       <li>Let |signal| be |options|'s {{CredentialRequestOptions/signal}}, if
       present.
       </li>
-      <li>If |origin| is an [=opaque origin=], return [=a promise rejected
-      with=] a {{"SecurityError"}} {{DOMException}}.
-      </li>
       <li>Let |global| be [=this=]'s [=relevant global object=].
       </li>
       <li>Let |document| be |global|'s [=associated `Document`=].
@@ -1711,9 +1711,6 @@
       </li>
       <li>If |signal| is [=AbortSignal/aborted=], return [=a promise rejected
       with=] |signal|'s [=AbortSignal/abort reason=].
-      </li>
-      <li>If |origin| is an [=opaque origin=], return [=a promise rejected
-      with=] a {{"SecurityError"}} {{DOMException}}.
       </li>
       <li>Let |global| be [=this=]'s [=relevant global object=].
       </li>
@@ -1901,15 +1898,6 @@
         injected through the network). Please refer to the
         [[[secure-contexts#security-considerations]]] section of the
         [[[secure-contexts]]] specification for more information.
-      </p>
-      <p>
-        Additionally, requests from an [=opaque origin=] are rejected. Calls to
-        {{DigitalCredential/[[DiscoverFromExternalSource]](origin, options,
-        sameOriginWithAncestors)}} and {{DigitalCredential/[[Create]](origin,
-        options, sameOriginWithAncestors)}} from an [=opaque origin=] (for
-        example, a `data:` document, or a document sandboxed without
-        `allow-same-origin`) are [=reject|rejected=], reducing the risk of
-        malicious extraction or spoofing from untrusted environments.
       </p>
       <p>
         The Digital Credentials API reduces [=API flooding=] through two

--- a/index.html
+++ b/index.html
@@ -880,9 +880,6 @@
     <ol class="algorithm">
       <li>Let |realm| be |global|'s [=relevant realm=].
       </li>
-      <li>If |origin| is an [=opaque origin=], return [=a promise rejected
-      with=] a {{"SecurityError"}} {{DOMException}} in |realm|.
-      </li>
       <li>Let |document| be |global|'s [=associated `Document`=].
       </li>
       <li>If |document| is not [=Document/fully active=], return [=a promise
@@ -1644,6 +1641,9 @@
       static boolean userAgentAllowsProtocol(DOMString protocol);
     };
     </pre>
+    <p>
+      {{DigitalCredential}} instances are [=Credential/origin bound=].
+    </p>
     <h4>
       The `protocol` member
     </h4>
@@ -2064,15 +2064,6 @@
         protocol-specific JSON payloads before acting on them.
       </p>
       <p>
-        Additionally, requests from an [=opaque origin=] are rejected. Calls to
-        {{DigitalCredential/[[DiscoverFromExternalSource]](origin, options,
-        sameOriginWithAncestors)}} and {{DigitalCredential/[[Create]](origin,
-        options, sameOriginWithAncestors)}} from an [=opaque origin=] (for
-        example, a `data:` document, or a document sandboxed without
-        `allow-same-origin`) are [=reject|rejected=], reducing the risk of
-        malicious extraction or spoofing from untrusted environments.
-      </p>
-      <p>
         The Digital Credentials API reduces [=API flooding=] through two
         mechanisms:
       </p>
@@ -2118,6 +2109,15 @@
         section [[[permissions-policy#privacy-and-security]]] of the
         [[[permissions-policy]]] specification for additional security
         properties provided by this integration.
+      </p>
+      <p>
+        Additionally, requests from an [=opaque origin=] are rejected. Because
+        {{DigitalCredential}} instances are [=Credential/origin bound=], calls
+        to request or create digital credentials from an [=opaque origin=] (for
+        example, a `data:` document, or a document sandboxed without
+        `allow-same-origin`) are rejected by [[[credential-management]]],
+        reducing the risk of malicious extraction or spoofing from untrusted
+        environments.
       </p>
       <section>
         <!--


### PR DESCRIPTION
Restores the origin-bound declaration on `DigitalCredential` (reverts #509) and removes the opaque-origin `SecurityError` check added in #535 (from `[[DiscoverFromExternalSource]]`, `[[Create]]`, and the mitigations note).

With `DigitalCredential` declared origin bound, Credential Management rejects a request for it from an opaque origin (companion PR w3c/webappsec-credential-management#304), so the per-algorithm check here is redundant.

Must not merge before w3c/webappsec-credential-management#304, or opaque origins would briefly not be rejected. Part of #560.

The following tasks have been completed:

- [x] Modified Web platform tests (https://github.com/web-platform-tests/wpt/pull/61188)

Implementation commitment:

- [X] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=318947). Already implemented. 
- [x] Chromium (link to issue). Already implemented. 
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/559.html" title="Last updated on Aug 21, 2026, 7:12 AM UTC (b71a411)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/559/2e9b687...b71a411.html" title="Last updated on Aug 21, 2026, 7:12 AM UTC (b71a411)">Diff</a>