### PR TITLE
Add requestOrigin attribute to DigitalCredential

### DIFF
--- a/index.html
+++ b/index.html
@@ -1109,7 +1109,7 @@
       {{AbortSignal}} |signal|:
     </p>
     <ol class="algorithm">
-      <li>Let |topLevelOrigin| be |document|'s [=top-level traversable=]'s
+      <li>Let |topLevelOrigin| be |document|'s [=node navigable=]'s [=navigable/top-level traversable=]'s
       [=navigable/active document=]'s [=relevant settings object=]'s
       [=environment settings object/origin=].
       </li>
@@ -1708,6 +1708,11 @@
       top-level traversable with user attention=], return [=a promise rejected
       with=] a {{"NotAllowedError"}} {{DOMException}}.
       </li>
+      <li>If |document|'s [=node navigable=]'s [=navigable/top-level traversable=]'s [=navigable/active
+      document=]'s [=relevant settings object=]'s [=environment settings
+      object/origin=] is an [=opaque origin=], return [=a promise rejected
+      with=] a {{"SecurityError"}} {{DOMException}}.
+      </li>
       <li>Let |requests| be |options|'s {{CredentialRequestOptions/digital}}'s
       {{DigitalCredentialRequestOptions/requests}} member.
       </li>
@@ -1765,6 +1770,11 @@
       <li>If |document| is not a [=Document/fully active descendant of a
       top-level traversable with user attention=], return [=a promise rejected
       with=] a {{"NotAllowedError"}} {{DOMException}}.
+      </li>
+      <li>If |document|'s [=node navigable=]'s [=navigable/top-level traversable=]'s [=navigable/active
+      document=]'s [=relevant settings object=]'s [=environment settings
+      object/origin=] is an [=opaque origin=], return [=a promise rejected
+      with=] a {{"SecurityError"}} {{DOMException}}.
       </li>
       <li>Let |requests| be |options|'s {{CredentialCreationOptions/digital}}'s
       {{DigitalCredentialCreationOptions/requests}} member.

--- a/index.html
+++ b/index.html
@@ -1071,9 +1071,14 @@
       {{AbortSignal}} |signal|:
     </p>
     <ol class="algorithm">
+      <li>Let |topLevelOrigin| be |document|'s [=top-level traversable=]'s
+      [=navigable/active document=]'s [=relevant settings object=]'s
+      [=environment settings object/origin=].
+      </li>
       <li>Let |requestData| be a new [=request context=] whose [=request
-      context/requests=] is |validatedRequests| and [=request context/document
-      origin=] is |documentOrigin|.
+      context/requests=] is |validatedRequests|, [=request context/document
+      origin=] is |documentOrigin|, and [=request context/top-level origin=] is
+      |topLevelOrigin|.
       </li>
       <li>[=In parallel=]:
         <ol>
@@ -1088,6 +1093,48 @@
               <li>The platform encounters an error.
               </li>
             </ul>
+            <p>
+              When displaying the [=digital credential chooser=]: if
+              |requestData|'s [=request context/document origin=] and its
+              [=request context/top-level origin=] are [=same site=], the
+              [=user agent=] SHOULD present the [=request context/top-level
+              origin=] to the user; otherwise, the [=user agent=] SHOULD
+              present both the [=request context/top-level origin=] and the
+              [=request context/document origin=], and SHOULD convey that the
+              [=request context/document origin=] is embedded within the page
+              at the [=request context/top-level origin=], and that the
+              [=request context/document origin=] would receive the requested
+              [=digital credential=].
+            </p>
+            <p class="note">
+              Presenting only the [=request context/document origin=] can
+              prevent the user from associating the request with the site they
+              are visiting, as that origin is typically not reflected in the
+              [=user agent=]'s address bar. Presenting only the [=request
+              context/top-level origin=] can mislead the user about which party
+              would receive the [=digital credential=]. Disclosing the
+              relationship between the two origins is analogous to the
+              cross-site relationship that the Storage Access API
+              [[?STORAGE-ACCESS]] is designed to surface. [[?webauthn-3]]
+              includes both the calling origin (its `origin` member) and, for
+              cross-origin requests, the top-level origin (its `topOrigin`
+              member) in its signed client data for verification by the relying
+              party; this specification is instead concerned with disclosing
+              that relationship to the user, which is otherwise not apparent
+              when the [=request context/document origin=] is not [=same site=]
+              with the [=request context/top-level origin=]. The requirement
+              above is about what the user is shown; where the [=digital
+              credential chooser=] is provided by the underlying platform, the
+              [=user agent=] makes both origins available to it for that
+              purpose.
+            </p>
+            <p class="issue" title=
+            "Cross-origin origin disclosure: SHOULD vs MUST">
+              Whether a [=user agent=] MUST, rather than SHOULD, present both
+              origins and convey their relationship for cross-origin requests,
+              and whether the request must be refused when both cannot be
+              conveyed to the user, is unresolved.
+            </p>
             <aside class="issue" data-number="456"></aside>
           </li>
           <li>If |signal| is not null and |signal| is [=AbortSignal/aborted=]:
@@ -1553,7 +1600,22 @@
         <dfn data-dfn-for="request context">document origin</dfn>
       </dt>
       <dd>
-        An [=origin=].
+        An [=origin=]; the [=origin=] in which the request was made, that is,
+        the [=current settings object=]'s [=environment settings
+        object/origin=] as provided to the internal methods in
+        [[[#credential-management-integration]]]. When the request is made from
+        a [=Document=] embedded in a cross-origin context, this is the embedded
+        [=Document=]'s [=origin=] and not the [=request context/top-level
+        origin=].
+      </dd>
+      <dt>
+        <dfn data-dfn-for="request context">top-level origin</dfn>
+      </dt>
+      <dd>
+        An [=origin=]; the [=top-level traversable=]'s [=navigable/active
+        document=]'s [=relevant settings object=]'s [=environment settings
+        object/origin=]. It is used only when presenting the request to the
+        user; it is not used to validate or form the request.
       </dd>
     </dl>
     <h4>

--- a/index.html
+++ b/index.html
@@ -1979,6 +1979,27 @@
         </li>
       </ul>
       <p>
+        The [=request context/document origin=] and [=request context/top-level
+        origin=] are determined by the [=user agent=]: the [=request
+        context/document origin=] is the [=origin=] passed to
+        {{DigitalCredential/[[DiscoverFromExternalSource]](origin, options,
+        sameOriginWithAncestors)}} and {{DigitalCredential/[[Create]](origin,
+        options, sameOriginWithAncestors)}} by the
+        [[[#credential-management-integration]]]; the [=request
+        context/top-level origin=] is that of the [=top-level traversable=]'s
+        [=navigable/active document=]. A [=user agent=] MUST use its own
+        determination of these [=origins=] and MUST NOT rely on an [=origin=]
+        supplied by the content whose request is being mediated, whether to
+        validate or form the request or to present the [=digital credential
+        chooser=].
+      </p>
+      <p>
+        This mitigates [=Unauthorized Cross-Origin Access=]: the party shown to
+        the user, and that would receive the [=digital credential=], reflects
+        the [=user agent=]'s own determination of who is asking, rather than a
+        value the requesting content can choose.
+      </p>
+      <p>
         For additional guidance on preventing abuse of credential requests,
         please refer to the section
         [[[credential-management#privacy-considerations]]] of the

--- a/index.html
+++ b/index.html
@@ -797,10 +797,11 @@
     </h3>
     <p>
       To <dfn data-dfn-for="credential request coordinator">prepare credential
-      requests</dfn> given a [=Document=] |document:Document|, a [=sequence=]
-      of {{DigitalCredentialGetRequest}} values or a [=sequence=] of
-      {{DigitalCredentialCreateRequest}} values |requests|, a {{Promise}}
-      |promise:Promise|, and an optional {{AbortSignal}} |signal:AbortSignal|:
+      requests</dfn> given an [=origin=] |documentOrigin|, a [=Document=]
+      |document:Document|, a [=sequence=] of {{DigitalCredentialGetRequest}}
+      values or a [=sequence=] of {{DigitalCredentialCreateRequest}} values
+      |requests|, a {{Promise}} |promise:Promise|, and an optional
+      {{AbortSignal}} |signal:AbortSignal|:
     </p>
     <ol class="algorithm">
       <li>Let |global| be |document|'s [=relevant global object=].
@@ -877,7 +878,8 @@
         </ol>
       </li>
       <li>[=credential request coordinator/Initiate the credential request=]
-      with |document|, |validatedRequests|, |promise|, and |signal|.
+      with |documentOrigin|, |document|, |validatedRequests|, |promise|, and
+      |signal|.
       </li>
       <li>If |document| stops being [=Document/fully active=], [=credential
       request coordinator/abort the credential request=] with an
@@ -1055,9 +1057,10 @@
     </h3>
     <p>
       To <dfn data-dfn-for="credential request coordinator">initiate the
-      credential request</dfn> given a [=Document=] |document|, a [=list=] of
-      validated credential requests |validatedRequests|, a {{Promise}}
-      |promise:Promise|, and an optional {{AbortSignal}} |signal|:
+      credential request</dfn> given an [=origin=] |documentOrigin|, a
+      [=Document=] |document|, a [=list=] of validated credential requests
+      |validatedRequests|, a {{Promise}} |promise:Promise|, and an optional
+      {{AbortSignal}} |signal|:
     </p>
     <ol class="algorithm">
       <li>Let |topLevelOrigin| be |document|'s [=top-level traversable=]'s
@@ -1065,8 +1068,9 @@
       [=environment settings object/origin=].
       </li>
       <li>Let |requestData| be a new [=request context=] whose [=request
-      context/requests=] is |validatedRequests| and [=request context/top-level
-      origin=] is |topLevelOrigin|.
+      context/requests=] is |validatedRequests|, [=request context/top-level
+      origin=] is |topLevelOrigin|, and [=request context/document origin=] is
+      |documentOrigin|.
       </li>
       <li>[=In parallel=]:
         <ol>
@@ -1552,6 +1556,12 @@
         An [=environment settings object=]'s [=environment settings
         object/origin=].
       </dd>
+      <dt>
+        <dfn data-dfn-for="request context">document origin</dfn>
+      </dt>
+      <dd>
+        An [=origin=].
+      </dd>
     </dl>
     <h4>
       The {{DigitalCredentialPresentationProtocol}} enumeration
@@ -1626,7 +1636,8 @@
       <li>Let |promise| be [=a new promise=] in [=this=]'s [=relevant realm=].
       </li>
       <li>[=credential request coordinator/Prepare credential requests=] with
-      |document|, |requests|, |promise|, and |signal|.
+      |origin| as |documentOrigin|, |document|, |requests|, |promise|, and
+      |signal|.
       </li>
       <li>Return |promise|.
       </li>
@@ -1684,7 +1695,8 @@
       [=this=].
       </li>
       <li>[=credential request coordinator/Prepare credential requests=] with
-      |document|, |requests|, |promise|, and |signal|.
+      |origin| as |documentOrigin|, |document|, |requests|, |promise|, and
+      |signal|.
       </li>
       <li>Return |promise|.
       </li>

--- a/index.html
+++ b/index.html
@@ -1132,30 +1132,39 @@
               </li>
             </ul>
             <p>
-              When displaying the [=digital credential chooser=]: if
-              |requestData|'s [=request context/document origin=] and its
-              [=request context/top-level origin=] are [=same site=], the
-              [=user agent=] SHOULD present the [=request context/top-level
-              origin=] to the user; otherwise, the [=user agent=] SHOULD
-              present both the [=request context/top-level origin=] and the
-              [=request context/document origin=], and SHOULD convey that the
-              [=request context/document origin=] is embedded within the page
-              at the [=request context/top-level origin=], and that the
-              [=request context/document origin=] would receive the requested
-              [=digital credential=].
+              The origins presented to the user are determined as follows:
             </p>
+            <dl class="switch">
+              <dt>
+                |requestData|'s [=request context/document origin=] and its
+                [=request context/top-level origin=] are [=same site=]:
+              </dt>
+              <dd>
+                The [=request context/top-level origin=] is presented to the
+                user.
+              </dd>
+              <dt>
+                Otherwise:
+              </dt>
+              <dd>
+                Both the [=request context/top-level origin=] and the [=request
+                context/document origin=] are presented to the user, conveying
+                that the [=request context/document origin=] is embedded within
+                the page at the [=request context/top-level origin=] and would
+                receive the requested [=digital credential=].
+              </dd>
+            </dl>
             <p class="note">
               Presenting only the [=request context/document origin=] can
               prevent the user from associating the request with the site they
               are visiting, as that origin is typically not reflected in the
               [=user agent=]'s address bar. Presenting only the [=request
               context/top-level origin=] can mislead the user about which party
-              would receive the [=digital credential=]. The requirement above
-              is about what the user is shown; where the [=digital credential
-              chooser=] is provided by the underlying platform, the [=user
-              agent=] makes both origins available to it for that purpose.
+              would receive the [=digital credential=]. Where the [=digital
+              credential chooser=] is provided by the underlying platform, the
+              [=user agent=] makes both origins available to it so that they
+              can be presented to the user.
             </p>
-            <aside class="issue" data-number="545"></aside>
             <aside class="issue" data-number="456"></aside>
           </li>
           <li>If |signal| is not null and |signal| is [=AbortSignal/aborted=]:

--- a/index.html
+++ b/index.html
@@ -1150,29 +1150,12 @@
               are visiting, as that origin is typically not reflected in the
               [=user agent=]'s address bar. Presenting only the [=request
               context/top-level origin=] can mislead the user about which party
-              would receive the [=digital credential=]. Disclosing the
-              relationship between the two origins is analogous to the
-              cross-site relationship that the Storage Access API
-              [[?STORAGE-ACCESS]] is designed to surface. [[?webauthn-3]]
-              includes both the calling origin (its `origin` member) and, for
-              cross-origin requests, the top-level origin (its `topOrigin`
-              member) in its signed client data for verification by the relying
-              party; this specification is instead concerned with disclosing
-              that relationship to the user, which is otherwise not apparent
-              when the [=request context/document origin=] is not [=same site=]
-              with the [=request context/top-level origin=]. The requirement
-              above is about what the user is shown; where the [=digital
-              credential chooser=] is provided by the underlying platform, the
-              [=user agent=] makes both origins available to it for that
-              purpose.
+              would receive the [=digital credential=]. The requirement above
+              is about what the user is shown; where the [=digital credential
+              chooser=] is provided by the underlying platform, the [=user
+              agent=] makes both origins available to it for that purpose.
             </p>
-            <p class="issue" title=
-            "Cross-origin origin disclosure: SHOULD vs MUST">
-              Whether a [=user agent=] MUST, rather than SHOULD, present both
-              origins and convey their relationship for cross-origin requests,
-              and whether the request must be refused when both cannot be
-              conveyed to the user, is unresolved.
-            </p>
+            <aside class="issue" data-number="545"></aside>
             <aside class="issue" data-number="456"></aside>
           </li>
           <li>If |signal| is not null and |signal| is [=AbortSignal/aborted=]:

--- a/index.html
+++ b/index.html
@@ -1068,14 +1068,9 @@
       {{AbortSignal}} |signal|:
     </p>
     <ol class="algorithm">
-      <li>Let |topLevelOrigin| be |document|'s [=top-level traversable=]'s
-      [=navigable/active document=]'s [=relevant settings object=]'s
-      [=environment settings object/origin=].
-      </li>
       <li>Let |requestData| be a new [=request context=] whose [=request
-      context/requests=] is |validatedRequests|, [=request context/top-level
-      origin=] is |topLevelOrigin|, and [=request context/document origin=] is
-      |documentOrigin|.
+      context/requests=] is |validatedRequests| and [=request context/document
+      origin=] is |documentOrigin|.
       </li>
       <li>[=In parallel=]:
         <ol>
@@ -1550,13 +1545,6 @@
       </dt>
       <dd>
         A [=list=] of validated [=digital credential/credential requests=].
-      </dd>
-      <dt>
-        <dfn data-dfn-for="request context">top-level origin</dfn>
-      </dt>
-      <dd>
-        An [=environment settings object=]'s [=environment settings
-        object/origin=].
       </dd>
       <dt>
         <dfn data-dfn-for="request context">document origin</dfn>

--- a/index.html
+++ b/index.html
@@ -1301,8 +1301,10 @@
                       <li>Let |credential| be a newly created
                       {{DigitalCredential}} instance with its
                       {{DigitalCredential/data}} initialized to
-                      |parsedResponseDataOrError| and its
-                      {{DigitalCredential/protocol}} initialized to |protocol|.
+                      |parsedResponseDataOrError|, its
+                      {{DigitalCredential/protocol}} initialized to |protocol|,
+                      and its {{DigitalCredential/requestOrigin}} initialized to
+                      the [=ASCII serialization of an origin=] of |documentOrigin|.
                       </li>
                       <li>[=Resolve=] |promise| with |credential|.
                       </li>
@@ -1544,6 +1546,7 @@
       [Default] object toJSON();
       readonly attribute DigitalCredentialProtocol protocol;
       [SameObject] readonly attribute object data;
+      readonly attribute USVString requestOrigin;
       static boolean userAgentAllowsProtocol(DOMString protocol);
     };
     </pre>
@@ -1563,6 +1566,14 @@
       The <dfn data-dfn-for="DigitalCredential">data</dfn> member is the
       credential's response data. It contains the subset of JSON-parseable
       object types.
+    </p>
+    <h4>
+      The `requestOrigin` attribute
+    </h4>
+    <p>
+      The <dfn data-dfn-for="DigitalCredential">requestOrigin</dfn> attribute is
+      the [=request context/document origin=] of the request that produced the
+      [=digital credential=].
     </p>
     <h4>
       The <dfn data-dfn-for="DigitalCredential">userAgentAllowsProtocol()</dfn>
@@ -2013,6 +2024,22 @@
         the user, and that would receive the [=digital credential=], reflects
         the [=user agent=]'s own determination of who is asking, rather than a
         value the requesting content can choose.
+      </p>
+      <p>
+        The {{DigitalCredential/requestOrigin}} attribute exposes this [=user
+        agent=]-determined [=request context/document origin=] on the response,
+        so it reflects the [=user agent=]'s determination rather than a value
+        chosen by the [=Document=], the platform, or the wallet. It is not,
+        however, a defense against a script running within the [=verifier=]'s
+        own page, which could substitute the {{DigitalCredential}} before a
+        downstream consumer reads it. A [=verifier=] therefore confirms the
+        origin a response was bound to by cryptographically validating the
+        response in {{DigitalCredential/data}} according to the [=digital
+        credential/presentation protocol=], rather than relying on
+        {{DigitalCredential/requestOrigin}} alone. That validation is only as
+        strong as the integrity of the request: a signed request authenticates
+        the [=verifier=] and integrity-protects the response's encryption
+        parameters and nonce, whereas an unsigned request does not.
       </p>
       <p>
         For additional guidance on preventing abuse of credential requests,


### PR DESCRIPTION
Exposes the origin the response was bound to on the returned credential, so an encrypted response can be tied to the origin it was produced for, consistent with how `protocol` and `data` make the response self-describing. Closes #566. Relates to #512, #520, #95.

The following tasks have been completed:

- [x] Web platform tests: the `requestOrigin` attribute is covered by WPT's auto-generated IDL (extracted from the published spec by Reffy into webref), which will pick it up automatically once this merges.

Implementation commitment:

- [ ] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=320435)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks:

- [ ] Affects privacy
- [x] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/567.html" title="Last updated on Aug 21, 2026, 12:51 AM UTC (66471d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/567/2b71d78...66471d2.html" title="Last updated on Aug 21, 2026, 12:51 AM UTC (66471d2)">Diff</a>