### PR TITLE
chore: add CI check for committed CRLF line endings

### DIFF
--- a/.github/workflows/line-endings.yml
+++ b/.github/workflows/line-endings.yml
@@ -6,6 +6,7 @@ name: Line Endings
 # small edit into a whole-file diff, so catch it here instead.
 
 on:
+  workflow_dispatch: {}
   push:
     branches:
       - main

--- a/.github/workflows/line-endings.yml
+++ b/.github/workflows/line-endings.yml
@@ -1,0 +1,30 @@
+name: Line Endings
+
+# .gitattributes normalizes line endings for local commits, but GitHub's
+# server-side commit paths (the "Apply suggestions from code review" batch
+# button, and the web file editor) bypass it and can commit CRLF. That turns a
+# small edit into a whole-file diff, so catch it here instead.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+permissions:
+  contents: read
+
+jobs:
+  crlf:
+    name: Check for CRLF
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Reject committed CRLF line endings
+        run: |
+          offenders=$(git ls-files --eol | grep -E 'i/(crlf|mixed)' || true)
+          if [ -n "$offenders" ]; then
+            echo "$offenders"
+            echo "::error::Committed files have CRLF line endings. Fix with: git add --renormalize . && git commit -m 'chore: normalize line endings to LF'"
+            exit 1
+          fi


### PR DESCRIPTION
GitHub's server-side commit paths (the batch "Apply suggestions from code review" button, and the web file editor) can commit CRLF, and `.gitattributes` does not prevent it because it is not applied to those commits; the result is a whole-file diff that hides the real change, as recently happened on #454, #539 and #512.

This adds a check that fails a pull request when any committed file has CRLF or mixed line endings, and prints the one-command fix (`git add --renormalize .`).