### PR TITLE
Editorial: deduplicate request prologue between get() and create()

### DIFF
--- a/index.html
+++ b/index.html
@@ -858,6 +858,9 @@
       </li>
       <li>Let |document| be |global|'s [=associated `Document`=].
       </li>
+      <li>If |document| is not [=Document/fully active=], return [=a promise
+      rejected with=] an {{"InvalidStateError"}} {{DOMException}}.
+      </li>
       <li>If |document| is not a [=Document/fully active descendant of a
       top-level traversable with user attention=], return [=a promise rejected
       with=] a {{"NotAllowedError"}} {{DOMException}}.

--- a/index.html
+++ b/index.html
@@ -853,24 +853,27 @@
       {{AbortSignal}} |signal:AbortSignal|:
     </p>
     <ol class="algorithm">
+      <li>Let |realm| be |global|'s [=relevant realm=].
+      </li>
       <li>If |origin| is an [=opaque origin=], return [=a promise rejected
-      with=] a {{"SecurityError"}} {{DOMException}}.
+      with=] a {{"SecurityError"}} {{DOMException}} in |realm|.
       </li>
       <li>Let |document| be |global|'s [=associated `Document`=].
       </li>
       <li>If |document| is not [=Document/fully active=], return [=a promise
-      rejected with=] an {{"InvalidStateError"}} {{DOMException}}.
+      rejected with=] an {{"InvalidStateError"}} {{DOMException}} in |realm|.
       </li>
       <li>If |document| is not a [=Document/fully active descendant of a
       top-level traversable with user attention=], return [=a promise rejected
-      with=] a {{"NotAllowedError"}} {{DOMException}}.
+      with=] a {{"NotAllowedError"}} {{DOMException}} in |realm|.
       </li>
       <li>If |global| does not have [=transient activation=], return [=a
-      promise rejected with=] a {{"NotAllowedError"}} {{DOMException}}.
+      promise rejected with=] a {{"NotAllowedError"}} {{DOMException}} in
+      |realm|.
       </li>
       <li>[=Consume user activation=] of |global|.
       </li>
-      <li>Let |promise| be [=a new promise=] in |global|'s [=relevant realm=].
+      <li>Let |promise| be [=a new promise=] in |realm|.
       </li>
       <li>If the [=credential request coordinator=] is not in the "[=credential
       request coordinator/idle=]" [=credential request coordinator/interaction

--- a/index.html
+++ b/index.html
@@ -847,16 +847,14 @@
     </h3>
     <p>
       To <dfn data-dfn-for="credential request coordinator">prepare credential
-      requests</dfn> given an [=origin=] |origin|, a [=sequence=] of
-      {{DigitalCredentialGetRequest}} values or a [=sequence=] of
-      {{DigitalCredentialCreateRequest}} values |requests|, and an optional
+      requests</dfn> given a {{Window}} |global|, an [=origin=] |origin|, a
+      [=sequence=] of {{DigitalCredentialGetRequest}} values or a [=sequence=]
+      of {{DigitalCredentialCreateRequest}} values |requests|, and an optional
       {{AbortSignal}} |signal:AbortSignal|:
     </p>
     <ol class="algorithm">
       <li>If |origin| is an [=opaque origin=], return [=a promise rejected
       with=] a {{"SecurityError"}} {{DOMException}}.
-      </li>
-      <li>Let |global| be [=this=]'s [=relevant global object=].
       </li>
       <li>Let |document| be |global|'s [=associated `Document`=].
       </li>
@@ -869,7 +867,7 @@
       </li>
       <li>[=Consume user activation=] of |global|.
       </li>
-      <li>Let |promise| be [=a new promise=] in [=this=]'s [=relevant realm=].
+      <li>Let |promise| be [=a new promise=] in |global|'s [=relevant realm=].
       </li>
       <li>If the [=credential request coordinator=] is not in the "[=credential
       request coordinator/idle=]" [=credential request coordinator/interaction
@@ -1673,8 +1671,10 @@
       <li>Let |signal| be |options|'s {{CredentialRequestOptions/signal}}, if
       present.
       </li>
+      <li>Let |global| be [=this=]'s [=relevant global object=].
+      </li>
       <li>Return the result of [=credential request coordinator/prepare
-      credential requests=] given |origin|, |requests|, and |signal|.
+      credential requests=] given |global|, |origin|, |requests|, and |signal|.
       </li>
     </ol><!--
     // MARK: [[Store]]()
@@ -1710,8 +1710,10 @@
       <li>Let |signal| be |options|'s {{CredentialCreationOptions/signal}}, if
       present.
       </li>
+      <li>Let |global| be [=this=]'s [=relevant global object=].
+      </li>
       <li>Return the result of [=credential request coordinator/prepare
-      credential requests=] given |origin|, |requests|, and |signal|.
+      credential requests=] given |global|, |origin|, |requests|, and |signal|.
       </li>
     </ol><!--
     // MARK: [[type]] internal slot

--- a/index.html
+++ b/index.html
@@ -847,13 +847,29 @@
     </h3>
     <p>
       To <dfn data-dfn-for="credential request coordinator">prepare credential
-      requests</dfn> given a [=Document=] |document:Document|, a [=sequence=]
-      of {{DigitalCredentialGetRequest}} values or a [=sequence=] of
-      {{DigitalCredentialCreateRequest}} values |requests|, a {{Promise}}
-      |promise:Promise|, and an optional {{AbortSignal}} |signal:AbortSignal|:
+      requests</dfn> given an [=origin=] |origin|, a [=sequence=] of
+      {{DigitalCredentialGetRequest}} values or a [=sequence=] of
+      {{DigitalCredentialCreateRequest}} values |requests|, and an optional
+      {{AbortSignal}} |signal:AbortSignal|:
     </p>
     <ol class="algorithm">
-      <li>Let |global| be |document|'s [=relevant global object=].
+      <li>If |origin| is an [=opaque origin=], return [=a promise rejected
+      with=] a {{"SecurityError"}} {{DOMException}}.
+      </li>
+      <li>Let |global| be [=this=]'s [=relevant global object=].
+      </li>
+      <li>Let |document| be |global|'s [=associated `Document`=].
+      </li>
+      <li>If |document| is not a [=Document/fully active descendant of a
+      top-level traversable with user attention=], return [=a promise rejected
+      with=] a {{"NotAllowedError"}} {{DOMException}}.
+      </li>
+      <li>If |global| does not have [=transient activation=], return [=a
+      promise rejected with=] a {{"NotAllowedError"}} {{DOMException}}.
+      </li>
+      <li>[=Consume user activation=] of |global|.
+      </li>
+      <li>Let |promise| be [=a new promise=] in [=this=]'s [=relevant realm=].
       </li>
       <li>If the [=credential request coordinator=] is not in the "[=credential
       request coordinator/idle=]" [=credential request coordinator/interaction
@@ -863,7 +879,7 @@
           given |global| to [=reject=] |promise| with a {{"NotAllowedError"}}
           {{DOMException}}.
           </li>
-          <li>Return.
+          <li>Return |promise|.
           </li>
         </ol>
       </li>
@@ -884,7 +900,7 @@
           <li>[=credential request coordinator/Reject the credential request
           with=] |error| and |promise|.
           </li>
-          <li>Return.
+          <li>Return |promise|.
           </li>
         </ol>
       </li>
@@ -893,7 +909,7 @@
           <li>[=credential request coordinator/Reject the credential request
           with=] a newly created {{TypeError}} and |promise|.
           </li>
-          <li>Return.
+          <li>Return |promise|.
           </li>
         </ol>
       </li>
@@ -934,10 +950,12 @@
       <li>Let |handled| be the result of running [=handle virtual wallet
       behavior=] given |promise| and |global|.
       </li>
-      <li>If |handled| is `true`, return.
+      <li>If |handled| is `true`, return |promise|.
       </li>
       <li>[=credential request coordinator/Initiate the credential request=]
       with |document|, |validatedRequests|, |promise|, and |signal|.
+      </li>
+      <li>Return |promise|.
       </li>
     </ol><!--
     // MARK: Validate credential requests
@@ -1649,34 +1667,14 @@
       Otherwise:
     </p>
     <ol class="algorithm">
-      <li>Let |signal| be |options|'s {{CredentialRequestOptions/signal}}, if
-      present.
-      </li>
-      <li>If |origin| is an [=opaque origin=], return [=a promise rejected
-      with=] a {{"SecurityError"}} {{DOMException}}.
-      </li>
-      <li>Let |global| be [=this=]'s [=relevant global object=].
-      </li>
-      <li>Let |document| be |global|'s [=associated `Document`=].
-      </li>
-      <li>If |document| is not a [=Document/fully active descendant of a
-      top-level traversable with user attention=], return [=a promise rejected
-      with=] a {{"NotAllowedError"}} {{DOMException}}.
-      </li>
       <li>Let |requests| be |options|'s {{CredentialRequestOptions/digital}}'s
       {{DigitalCredentialRequestOptions/requests}} member.
       </li>
-      <li>If |global| does not have [=transient activation=], return [=a
-      promise rejected with=] a {{"NotAllowedError"}} {{DOMException}}.
+      <li>Let |signal| be |options|'s {{CredentialRequestOptions/signal}}, if
+      present.
       </li>
-      <li>[=Consume user activation=] of |global|.
-      </li>
-      <li>Let |promise| be [=a new promise=] in [=this=]'s [=relevant realm=].
-      </li>
-      <li>[=credential request coordinator/Prepare credential requests=] with
-      |document|, |requests|, |promise|, and |signal|.
-      </li>
-      <li>Return |promise|.
+      <li>Return the result of [=credential request coordinator/prepare
+      credential requests=] given |origin|, |requests|, and |signal|.
       </li>
     </ol><!--
     // MARK: [[Store]]()
@@ -1706,38 +1704,14 @@
       arguments. Otherwise:
     </p>
     <ol class="algorithm">
-      <li>Let |signal| be |options|'s {{CredentialCreationOptions/signal}}, if
-      present.
-      </li>
-      <li>If |signal| is [=AbortSignal/aborted=], return [=a promise rejected
-      with=] |signal|'s [=AbortSignal/abort reason=].
-      </li>
-      <li>If |origin| is an [=opaque origin=], return [=a promise rejected
-      with=] a {{"SecurityError"}} {{DOMException}}.
-      </li>
-      <li>Let |global| be [=this=]'s [=relevant global object=].
-      </li>
-      <li>Let |document| be |global|'s [=associated `Document`=].
-      </li>
-      <li>If |document| is not a [=Document/fully active descendant of a
-      top-level traversable with user attention=], return [=a promise rejected
-      with=] a {{"NotAllowedError"}} {{DOMException}}.
-      </li>
       <li>Let |requests| be |options|'s {{CredentialCreationOptions/digital}}'s
       {{DigitalCredentialCreationOptions/requests}} member.
       </li>
-      <li>If |global| does not have [=transient activation=], return [=a
-      promise rejected with=] a {{"NotAllowedError"}} {{DOMException}}.
+      <li>Let |signal| be |options|'s {{CredentialCreationOptions/signal}}, if
+      present.
       </li>
-      <li>[=Consume user activation=] of |global|.
-      </li>
-      <li>Let |promise : Promise| be [=a new promise=] in the [=relevant
-      realm=] of [=this=].
-      </li>
-      <li>[=credential request coordinator/Prepare credential requests=] with
-      |document|, |requests|, |promise|, and |signal|.
-      </li>
-      <li>Return |promise|.
+      <li>Return the result of [=credential request coordinator/prepare
+      credential requests=] given |origin|, |requests|, and |signal|.
       </li>
     </ol><!--
     // MARK: [[type]] internal slot


### PR DESCRIPTION
Moves the common request prologue steps (`opaque origin` check, global/document activity check, transient user activation check & consumption, and promise creation) into `[[prepare credential requests]]`, returning the resulting promise.

`[[DiscoverFromExternalSource]]` and `[[Create]]` now simply extract the requested credentials and abort signal from options and delegate to `[[prepare credential requests]]`.

This provides a single source of truth for request prologue checks, eliminating the source of duplication that caused PRs like #535, #547, #557, #558, and #559 to repeat edits across both internal methods.

No linked issue.

The following tasks have been completed:

- [x] ~~Modified Web platform tests~~ — no observable change intended. Existing coverage that would catch a regression here is `create.tentative.https.html` (aborted signal on `create()`) and `get-non-fully-active.https.html` / `create-non-fully-active.https.html`.

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

A spec-internal refactor, so no engine work is expected, provided the moved prologue keeps the same steps in the same order.

Documentation and checks

- [ ] Affects privacy
- [ ] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/573.html" title="Last updated on Aug 19, 2026, 4:59 AM UTC (a80b2ea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/573/a3418c4...a80b2ea.html" title="Last updated on Aug 19, 2026, 4:59 AM UTC (a80b2ea)">Diff</a>