### PR TITLE
Apply friction when a request carries no signature to check

### DIFF
--- a/index.html
+++ b/index.html
@@ -1114,6 +1114,21 @@
       context/requests=] is |validatedRequests| and [=request context/top-level
       origin=] is |topLevelOrigin|.
       </li>
+      <li>If a [=digital credential/credential request=] in |validatedRequests|
+      carries no signature that a [=credential manager=] can verify, the [=user
+      agent=] SHOULD apply additional friction when displaying the [=digital
+      credential chooser=], and strongly discourage the user from continuing.
+        <p class="note" title="Why friction here">
+          An unsigned request can be altered by a script running in the
+          [=verifier=]'s own page, including the parameters used to encrypt the
+          response, and neither the [=credential manager=] nor the [=verifier=]
+          can detect that it happened. Requests are transmitted unencrypted so
+          that a [=user agent=] can inspect them for exactly this kind of risk
+          analysis. A user who declines is handled by the steps below, which
+          [=credential request coordinator/reject the credential request with=]
+          a {{"NotAllowedError"}} {{DOMException}}.
+        </p>
+      </li>
       <li>[=In parallel=]:
         <ol>
           <li>Display a [=digital credential chooser=] with |requestData| and


### PR DESCRIPTION
Closes #571

Adds a step to the initiate the credential request algorithm: when a request carries no signature a credential manager can verify, the user agent applies additional friction as it shows the chooser and steers the user away from continuing. It sits immediately before the chooser is displayed because that is the moment the user decides.

The following tasks have been completed:

- [x] ~~Modified Web platform tests~~ — user-facing friction is not web-observable

Implementation commitment:

- [ ] WebKit (link to issue)
- [ ] Chromium (link to issue)
- [ ] Gecko (link to issue)

Documentation and checks

- [ ] Affects privacy
- [x] Affects security
- [ ] Pinged MDN
- [ ] Updated Explainer
- [ ] Updated digitalcredentials.dev


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/pull/575.html" title="Last updated on Aug 21, 2026, 2:11 AM UTC (a4cc0f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/digital-credentials/575/2e9b687...a4cc0f9.html" title="Last updated on Aug 21, 2026, 2:11 AM UTC (a4cc0f9)">Diff</a>